### PR TITLE
Moved array instantiation in to method scope

### DIFF
--- a/apr_base.py
+++ b/apr_base.py
@@ -49,12 +49,12 @@ v2_pools = {
             }
     }
 
-data = []
 web3_url = os.getenv("AURORA_W3_URL", "https://mainnet.aurora.dev/")
 w3 = Web3(Web3.HTTPProvider(web3_url))
 
 def apr_base():
     print("Starting APR BASE")
+    data = []
     ## chef calls
     decimals = 18
     chef = init_chef(w3)


### PR DESCRIPTION
Since `data = []` was defined out of the scope of `apr_base`, it caused
- `datav2.json` file to grow since the array was never emptied
- memory usage of cloud function to continually increase

Confirmed that outputs before and after change are correct