### PR TITLE
Added logging for MECHA USDC; Fixed MECHA:WNEAR token order

### DIFF
--- a/apr_base.py
+++ b/apr_base.py
@@ -92,6 +92,7 @@ def apr_base():
     print(f"Aurora USDC Ratio: {auroraUsdcRatio/10**12}")
     print(f"LUNA USDC Ratio: {lunaUsdcRatio}")
     print(f"FLX USDC Ratio: {flxUsdcRatio}")
+    print(f"MECHA USDC Ratio: {mechaUsdcRatio/10**12}")
 
 
     for id, address in v1_pools.items():

--- a/utils.py
+++ b/utils.py
@@ -171,9 +171,9 @@ def getMechaUsdcRatio(w3):
     reserves = mechaWnearPair.functions.getReserves().call()
 
     if t0 == MECHA_ADDRESS:
-        mechaWnearRatio = reserves[1]/reserves[0]
-    else:
         mechaWnearRatio = reserves[0]/reserves[1]
+    else:
+        mechaWnearRatio = reserves[1]/reserves[0]
     
     usdcWnearPair = init_tlp(w3, WNEAR_USDC)
     t1 = usdcWnearPair.functions.token1().call()


### PR DESCRIPTION
Added logging to validate MECHA:USDC ratio 

### Before:
`MECHA USDC Ratio: 1.339988662274882e+21`

### After:
`MECHA USDC Ratio: 6.427876874994535`

Validated on UI:
![image](https://user-images.githubusercontent.com/94581898/151296032-d667e4b8-94a5-4180-8c79-5ca04d512f48.png)


### APR Before:
`"apr2": 8.178078041518642e-06`

### APR After:
`"apr2": 1695.9567662676288`
