### PR TITLE
Implemented rewarderConfigs.json to existing APR calculations

### DIFF
--- a/apr_base.py
+++ b/apr_base.py
@@ -89,7 +89,7 @@ def apr_base():
     fetched_rewarder_configs = getRewarderConfigs()
     for rewarder_config in fetched_rewarder_configs:
         id, pool = formatRewarderConfigItem(rewarder_config)
-        print(f"V3 Reached here {id}: {pool['LP']}")
+        print(f"Fetched V2 Reached here {id}: {pool['LP']}")
 
         data.append(
             getDataV2Pools(

--- a/apr_base.py
+++ b/apr_base.py
@@ -2,14 +2,14 @@ from utils.node import (
     w3,
     init_chef,
     init_chefv2,
-    )
+)
 from utils.prices import (
     getDexTokenUSDRatio,
-    )
+)
 from utils.reserves import (
     getDataV1Pools,
     getDataV2Pools,
-    )
+)
 from utils.constants import (
     V1_POOLS,
     V2_POOLS,
@@ -20,12 +20,13 @@ from utils.constants import (
     TRI_ADDRESS,
     WNEAR_TRI,
 )
+from utils.rewarder_configs import formatRewarderConfigItem, getRewarderConfigs
 
 
 def apr_base():
     print("Starting APR BASE")
     data = []
-    
+
     ## chef data
     tri_decimals = 18
     chef = init_chef()
@@ -38,9 +39,11 @@ def apr_base():
     dummyLpPoolInfo = chef.functions.poolInfo(dummyLPPoolId).call()
     assert dummyLpPoolInfo[0].lower() == dummyLPToken.lower()
     dummyLpAllocPoint = dummyLpPoolInfo[1]
-    dummyLpTotalSecondRewardRate = (triPerBlock * dummyLpAllocPoint / (totalAllocPoint * 10 ** tri_decimals))
+    dummyLpTotalSecondRewardRate = (
+        triPerBlock * dummyLpAllocPoint / (totalAllocPoint * 10**tri_decimals)
+    )
 
-    #Chef V2 calls
+    # Chef V2 calls
     chefv2 = init_chefv2()
     totalAllocPointV2 = chefv2.functions.totalAllocPoint().call()
 
@@ -48,23 +51,22 @@ def apr_base():
     wnearUsdRatio = getDexTokenUSDRatio(w3, WNEAR_USDC, WNEAR_ADDRESS)
     wethUsdRatio = getDexTokenUSDRatio(w3, WETH_USDC, WETH_ADDRESS)
     triUsdRatio = getDexTokenUSDRatio(w3, WNEAR_TRI, TRI_ADDRESS, wnearUsdRatio)
-    
-    
+
     for id, address in V1_POOLS.items():
         print("V1 Reached here", address)
         # Chef V1
         data.append(
             getDataV1Pools(
-                w3, 
+                w3,
                 id,
-                address, 
-                chef, 
-                triPerBlock, 
-                totalAllocPoint, 
-                tri_decimals, 
-                triUsdRatio, 
-                wnearUsdRatio, 
-                wethUsdRatio
+                address,
+                chef,
+                triPerBlock,
+                totalAllocPoint,
+                tri_decimals,
+                triUsdRatio,
+                wnearUsdRatio,
+                wethUsdRatio,
             )
         )
 
@@ -72,18 +74,39 @@ def apr_base():
         print(f"V2 Reached here {id}: {pool['LP']}")
         data.append(
             getDataV2Pools(
-                w3, 
+                w3,
                 id,
-                pool, 
-                chefv2, 
-                dummyLpTotalSecondRewardRate, 
-                totalAllocPointV2, 
-                triUsdRatio, 
-                wnearUsdRatio, 
-                wethUsdRatio
-            )    
+                pool,
+                chefv2,
+                dummyLpTotalSecondRewardRate,
+                totalAllocPointV2,
+                triUsdRatio,
+                wnearUsdRatio,
+                wethUsdRatio,
+            )
         )
+
+    fetched_rewarder_configs = getRewarderConfigs()
+    for rewarder_config in fetched_rewarder_configs:
+        id, pool = formatRewarderConfigItem(rewarder_config)
+        print(f"V3 Reached here {id}: {pool['LP']}")
+
+        data.append(
+            getDataV2Pools(
+                w3,
+                id,
+                pool,
+                chefv2,
+                dummyLpTotalSecondRewardRate,
+                totalAllocPointV2,
+                triUsdRatio,
+                wnearUsdRatio,
+                wethUsdRatio,
+            )
+        )
+
     return data
+
 
 if __name__ == "__main__":
     apr_base()

--- a/datav2.json
+++ b/datav2.json
@@ -3,12 +3,12 @@
         "id": 0,
         "poolId": 0,
         "lpAddress": "0x63da4DB6Ef4e7C62168aB03982399F9588fCd198",
-        "totalSupply": 26595645052377728144388470,
-        "totalStaked": 26160120842073724430610686,
-        "totalStakedInUSD": 3757614.733924997,
+        "totalSupply": 27361128205409635789504592,
+        "totalStaked": 27036234028766276672844759,
+        "totalStakedInUSD": 5219097.68210479,
         "totalRewardRate": 266112.0,
         "allocPoint": 11,
-        "apr": 11.438637749514092,
+        "apr": 8.826649060457642,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -16,9 +16,9 @@
         "id": 1,
         "poolId": 1,
         "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
-        "totalSupply": 1716018199606673270598,
-        "totalStaked": 24577849008052880563,
-        "totalStakedInUSD": 110476.59326395461,
+        "totalSupply": 1630523950311661362458,
+        "totalStaked": 23586054740465858382,
+        "totalStakedInUSD": 120592.84979348998,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -29,9 +29,9 @@
         "id": 2,
         "poolId": 2,
         "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
-        "totalSupply": 1075975804291523346025,
-        "totalStaked": 37652591061278298215,
-        "totalStakedInUSD": 174899.14366384025,
+        "totalSupply": 1067557381841407631989,
+        "totalStaked": 32497216769816744132,
+        "totalStakedInUSD": 171655.88437018203,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -42,12 +42,12 @@
         "id": 3,
         "poolId": 3,
         "lpAddress": "0x2fe064B6c7D274082aa5d2624709bC9AE7D16C77",
-        "totalSupply": 2515859558373,
-        "totalStaked": 2407348307932,
-        "totalStakedInUSD": 5002178.498870603,
+        "totalSupply": 2375130593599,
+        "totalStaked": 2265760706642,
+        "totalStakedInUSD": 4710198.886445136,
         "totalRewardRate": 120960.0,
         "allocPoint": 5,
-        "apr": 3.905752241322033,
+        "apr": 4.445589508174148,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -55,12 +55,12 @@
         "id": 4,
         "poolId": 4,
         "lpAddress": "0xbc8A244e8fb683ec1Fd6f88F3cc6E565082174Eb",
-        "totalSupply": 53375804097131842431,
-        "totalStaked": 53349638590183455811,
-        "totalStakedInUSD": 2980797.7759134388,
+        "totalSupply": 42363126370907535345,
+        "totalStaked": 42319145790866352378,
+        "totalStakedInUSD": 2879054.7045179107,
         "totalRewardRate": 266112.0,
         "allocPoint": 11,
-        "apr": 14.419627554382947,
+        "apr": 16.00078789051725,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -68,12 +68,12 @@
         "id": 5,
         "poolId": 5,
         "lpAddress": "0x84b123875F0F36B966d0B6Ca14b31121bd9676AD",
-        "totalSupply": 621732146588216182872691349,
-        "totalStaked": 376063540118234222165307150,
-        "totalStakedInUSD": 1005878.014127642,
+        "totalSupply": 588683420367480168610985616,
+        "totalStaked": 334788175562050085237587503,
+        "totalStakedInUSD": 1047754.805433269,
         "totalRewardRate": 532224.0,
         "allocPoint": 22,
-        "apr": 85.46164274379015,
+        "apr": 87.93496992483306,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -81,9 +81,9 @@
         "id": 6,
         "poolId": 6,
         "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
-        "totalSupply": 3548112413278240296438,
+        "totalSupply": 3540753587453804796187,
         "totalStaked": 23154754023999468509,
-        "totalStakedInUSD": 1892.3031795424647,
+        "totalStakedInUSD": 2585.309017399418,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -94,16 +94,16 @@
         "id": 7,
         "poolId": 0,
         "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
-        "totalSupply": 3548112413278240296438,
-        "totalStaked": 3486517056265737628279,
-        "totalStakedInUSD": 284932.7314927404,
-        "totalRewardRate": 24925.09090909091,
+        "totalSupply": 3540753587453804796187,
+        "totalStaked": 3475180195005212790172,
+        "totalStakedInUSD": 388015.9852237112,
+        "totalRewardRate": 23957.126213592237,
         "allocPoint": 4,
-        "apr": 14.12916533619548,
+        "apr": 10.688381071352653,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 22.54982798257654
+                "apr": 22.440444009244256
             }
         ],
         "chefVersion": "v2"
@@ -112,16 +112,16 @@
         "id": 8,
         "poolId": 1,
         "lpAddress": "0xd1654a7713617d41A8C9530Fb9B948d00e162194",
-        "totalSupply": 505005873762281357671669,
-        "totalStaked": 500565834565597259285612,
-        "totalStakedInUSD": 213702.51803710524,
-        "totalRewardRate": 105931.63636363635,
+        "totalSupply": 529090428648458639924454,
+        "totalStaked": 524070491686773820912201,
+        "totalStakedInUSD": 270031.02371103177,
+        "totalRewardRate": 101817.78640776698,
         "allocPoint": 17,
-        "apr": 80.06415772362011,
+        "apr": 65.27348703537585,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 30.06601953399238
+                "apr": 32.24537266659525
             }
         ],
         "chefVersion": "v2"
@@ -132,7 +132,7 @@
         "lpAddress": "0xdF8CbF89ad9b7dAFdd3e37acEc539eEcC8c47914",
         "totalSupply": 1992609663450937245917415,
         "totalStaked": 1465070334631470132633836,
-        "totalStakedInUSD": 96.66333181041028,
+        "totalStakedInUSD": 93.7908375306229,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -148,9 +148,9 @@
         "id": 10,
         "poolId": 3,
         "lpAddress": "0xa9eded3E339b9cd92bB6DEF5c5379d678131fF90",
-        "totalSupply": 51349875894344588615727989,
-        "totalStaked": 36196552898454948143079715,
-        "totalStakedInUSD": 41985.57633885974,
+        "totalSupply": 51243312764057220290229692,
+        "totalStaked": 36177733487391393378873918,
+        "totalStakedInUSD": 35035.04991794496,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -166,12 +166,12 @@
         "id": 11,
         "poolId": 4,
         "lpAddress": "0x61C9E05d1Cdb1b70856c7a2c53fA9c220830633c",
-        "totalSupply": 62979448217362075,
-        "totalStaked": 62091299183855215,
-        "totalStakedInUSD": 511493.613557247,
-        "totalRewardRate": 261713.45454545456,
+        "totalSupply": 62430656733675489,
+        "totalStaked": 61520077333787901,
+        "totalStakedInUSD": 528593.6462964762,
+        "totalRewardRate": 251549.82524271845,
         "allocPoint": 42,
-        "apr": 82.64335359349212,
+        "apr": 82.38135055065194,
         "nonTriAPRs": [],
         "chefVersion": "v2"
     },
@@ -179,9 +179,9 @@
         "id": 12,
         "poolId": 5,
         "lpAddress": "0x6443532841a5279cb04420E61Cf855cBEb70dc8C",
-        "totalSupply": 1422548767022222137180211,
+        "totalSupply": 1420536797092117388501909,
         "totalStaked": 1163899784224777687044602,
-        "totalStakedInUSD": 19576.749725295933,
+        "totalStakedInUSD": 26730.256925047146,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -194,7 +194,7 @@
         "lpAddress": "0x7be4a49AA41B34db70e539d4Ae43c7fBDf839DfA",
         "totalSupply": 2229360188498831487239,
         "totalStaked": 1281331265594686716048,
-        "totalStakedInUSD": 79.96115788634675,
+        "totalStakedInUSD": 99.089279119941,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -207,7 +207,7 @@
         "lpAddress": "0x3dC236Ea01459F57EFc737A12BA3Bb5F3BFfD071",
         "totalSupply": 748541184021155708110682,
         "totalStaked": 427493138825209133119227,
-        "totalStakedInUSD": 1210.8211501810772,
+        "totalStakedInUSD": 1780.9291632938507,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -218,16 +218,16 @@
         "id": 15,
         "poolId": 8,
         "lpAddress": "0x48887cEEA1b8AD328d5254BeF774Be91B90FaA09",
-        "totalSupply": 422426971310265403587823717,
-        "totalStaked": 279232569490269600149739406,
-        "totalStakedInUSD": 355896.85094504803,
-        "totalRewardRate": 24925.09090909091,
+        "totalSupply": 422940518844127217094361911,
+        "totalStaked": 279742753838845449471846479,
+        "totalStakedInUSD": 370694.27242344077,
+        "totalRewardRate": 23957.126213592237,
         "allocPoint": 4,
-        "apr": 11.311877759706087,
+        "apr": 11.187825171223537,
         "nonTriAPRs": [
             {
                 "address": "0xea62791aa682d455614eaA2A12Ba3d9A2fD197af",
-                "apr": 35.18300355721151
+                "apr": 28.485130070578027
             }
         ],
         "chefVersion": "v2"
@@ -236,9 +236,9 @@
         "id": 16,
         "poolId": 9,
         "lpAddress": "0xd62f9ec4C4d323A0C111d5e78b77eA33A2AA862f",
-        "totalSupply": 21568496832191584678577517,
-        "totalStaked": 12900414361034006977889525,
-        "totalStakedInUSD": 448.5872413618347,
+        "totalSupply": 14892858868705209230463066,
+        "totalStaked": 9942432426695922758814344,
+        "totalStakedInUSD": 638.4428229606672,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -254,16 +254,16 @@
         "id": 17,
         "poolId": 10,
         "lpAddress": "0xdDAdf88b007B95fEb42DDbd110034C9a8e9746F2",
-        "totalSupply": 359968634470161913943880535,
-        "totalStaked": 28382390884410497911022208,
-        "totalStakedInUSD": 12585.01495059375,
+        "totalSupply": 362232453593319117271071108,
+        "totalStaked": 31815106110529732237598361,
+        "totalStakedInUSD": 17404.717352170777,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x501acE9c35E60f03A2af4d484f49F9B1EFde9f40",
-                "apr": 2679.5328253715475
+                "apr": 2182.0874325580926
             }
         ],
         "chefVersion": "v2"
@@ -272,9 +272,9 @@
         "id": 18,
         "poolId": 11,
         "lpAddress": "0x5913f644A10d98c79F2e0b609988640187256373",
-        "totalSupply": 27486156832105721632061099,
-        "totalStaked": 23008683404109945913141965,
-        "totalStakedInUSD": 18780.3210232358,
+        "totalSupply": 21151143912399237299356219,
+        "totalStaked": 16944947684374957832348440,
+        "totalStakedInUSD": 15855.805504357446,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -290,16 +290,16 @@
         "id": 19,
         "poolId": 12,
         "lpAddress": "0x47924Ae4968832984F4091EEC537dfF5c38948a4",
-        "totalSupply": 86822514789303020500149487126,
-        "totalStaked": 84426668739330127696946428848,
-        "totalStakedInUSD": 627645.4676175169,
-        "totalRewardRate": 24925.09090909091,
+        "totalSupply": 53293879770320174602005207947,
+        "totalStaked": 50769568946374245898616418261,
+        "totalStakedInUSD": 481999.3866362717,
+        "totalRewardRate": 23957.126213592237,
         "allocPoint": 4,
-        "apr": 6.414228861137982,
+        "apr": 8.604290434454409,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 1.928550509102618
+                "apr": 3.0017959423714413
             }
         ],
         "chefVersion": "v2"
@@ -308,16 +308,16 @@
         "id": 20,
         "poolId": 13,
         "lpAddress": "0xb419ff9221039Bdca7bb92A131DD9CF7DEb9b8e5",
-        "totalSupply": 31207865822600742079539,
-        "totalStaked": 31161395787230174928350,
-        "totalStakedInUSD": 12632.680453670699,
+        "totalSupply": 36595977452752424379453,
+        "totalStaked": 36544336546696907994610,
+        "totalStakedInUSD": 16507.763713647237,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x7cA1C28663b76CFDe424A9494555B94846205585",
-                "apr": 257.41615043734674
+                "apr": 233.67126069210497
             }
         ],
         "chefVersion": "v2"
@@ -326,9 +326,9 @@
         "id": 21,
         "poolId": 14,
         "lpAddress": "0xFBc4C42159A5575a772BebA7E3BF91DB508E127a",
-        "totalSupply": 3386496144683004840955260,
-        "totalStaked": 3222643870554468048542824,
-        "totalStakedInUSD": 2167.068888306288,
+        "totalSupply": 3198973892524503138860982,
+        "totalStaked": 3034474738670783040974573,
+        "totalStakedInUSD": 2605.3182831805257,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -346,7 +346,7 @@
         "lpAddress": "0x7B273238C6DD0453C160f305df35c350a123E505",
         "totalSupply": 10708874798944864,
         "totalStaked": 445457592890239,
-        "totalStakedInUSD": 1032.9913038105713,
+        "totalStakedInUSD": 1009.7902622978673,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -362,16 +362,16 @@
         "id": 23,
         "poolId": 16,
         "lpAddress": "0x6277f94a69Df5df0Bc58b25917B9ECEFBf1b846A",
-        "totalSupply": 713153939829,
-        "totalStaked": 617882095759,
-        "totalStakedInUSD": 121622.95944837268,
+        "totalSupply": 456109182848,
+        "totalStaked": 262505713006,
+        "totalStakedInUSD": 48237.06171871847,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
-                "apr": 34.27568980141303
+                "apr": 109.94562650732878
             }
         ],
         "chefVersion": "v2"
@@ -380,16 +380,16 @@
         "id": 24,
         "poolId": 17,
         "lpAddress": "0xadAbA7E2bf88Bd10ACb782302A568294566236dC",
-        "totalSupply": 47706833538892040166986423,
-        "totalStaked": 47315893560724243653348035,
-        "totalStakedInUSD": 10131.189929039452,
+        "totalSupply": 50275851857621514910503405,
+        "totalStaked": 49248474523911739827354718,
+        "totalStakedInUSD": 10275.678846140827,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x4148d2Ce7816F0AE378d98b40eB3A7211E1fcF0D",
-                "apr": 83.12913509318378
+                "apr": 60.99282119833254
             }
         ],
         "chefVersion": "v2"
@@ -398,9 +398,9 @@
         "id": 25,
         "poolId": 18,
         "lpAddress": "0x5EB99863f7eFE88c447Bc9D52AA800421b1de6c9",
-        "totalSupply": 1613011568872611708610,
+        "totalSupply": 1313694720091632885224,
         "totalStaked": 1009954227594396962,
-        "totalStakedInUSD": 1.1084427100335814,
+        "totalStakedInUSD": 1.109722500266017,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -411,12 +411,12 @@
         "id": 26,
         "poolId": 19,
         "lpAddress": "0x5E74D85311fe2409c341Ce49Ce432BB950D221DE",
-        "totalSupply": 406547230211854004,
-        "totalStaked": 399515741845414309,
-        "totalStakedInUSD": 11636.706830360112,
-        "totalRewardRate": 6231.272727272728,
+        "totalSupply": 300922401487583109,
+        "totalStaked": 293890907202155267,
+        "totalStakedInUSD": 8017.3597830431645,
+        "totalRewardRate": 5989.281553398059,
         "allocPoint": 1,
-        "apr": 86.49057099323126,
+        "apr": 129.32133595335486,
         "nonTriAPRs": [],
         "chefVersion": "v2"
     },
@@ -424,16 +424,16 @@
         "id": 27,
         "poolId": 20,
         "lpAddress": "0xbe753E99D0dBd12FB39edF9b884eBF3B1B09f26C",
-        "totalSupply": 68837566753930559191006538,
-        "totalStaked": 67355680225490934350106933,
-        "totalStakedInUSD": 18914.125542020036,
-        "totalRewardRate": 6231.272727272728,
+        "totalSupply": 70927686505676546994555524,
+        "totalStaked": 69521710678907545846233046,
+        "totalStakedInUSD": 19529.22205756185,
+        "totalRewardRate": 5989.281553398059,
         "allocPoint": 1,
-        "apr": 53.21236850219138,
+        "apr": 53.0904751303383,
         "nonTriAPRs": [
             {
                 "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
-                "apr": 44.01526510524515
+                "apr": 33.27704984311336
             }
         ],
         "chefVersion": "v2"
@@ -442,16 +442,16 @@
         "id": 28,
         "poolId": 21,
         "lpAddress": "0xbC0e71aE3Ef51ae62103E003A9Be2ffDe8421700",
-        "totalSupply": 18768320911331839462270662,
-        "totalStaked": 18761884514046123266772005,
-        "totalStakedInUSD": 71011.29291856232,
-        "totalRewardRate": 6231.272727272728,
+        "totalSupply": 12765099909132771850598388,
+        "totalStaked": 12761054610448298302281591,
+        "totalStakedInUSD": 54872.45139627044,
+        "totalRewardRate": 5989.281553398059,
         "allocPoint": 1,
-        "apr": 14.173314931653508,
+        "apr": 18.8950129177628,
         "nonTriAPRs": [
             {
                 "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
-                "apr": 11.723631773901735
+                "apr": 11.843372753907714
             }
         ],
         "chefVersion": "v2"
@@ -460,16 +460,16 @@
         "id": 29,
         "poolId": 22,
         "lpAddress": "0xbceA13f9125b0E3B66e979FedBCbf7A4AfBa6fd1",
-        "totalSupply": 73830692540818621221725347780,
-        "totalStaked": 73765656566692986042366456337,
-        "totalStakedInUSD": 519578.97821730253,
-        "totalRewardRate": 12462.545454545456,
+        "totalSupply": 49301696023533860554444418870,
+        "totalStaked": 49292394914410907264458238827,
+        "totalStakedInUSD": 443077.3590505246,
+        "totalRewardRate": 11978.563106796119,
         "allocPoint": 2,
-        "apr": 3.8741575792458187,
+        "apr": 4.680066163541487,
         "nonTriAPRs": [
             {
                 "address": "0x918dBe087040A41b786f0Da83190c293DAe24749",
-                "apr": 7.51069522193752
+                "apr": 11.260142863499507
             }
         ],
         "chefVersion": "v2"
@@ -478,16 +478,16 @@
         "id": 30,
         "poolId": 23,
         "lpAddress": "0xBBf3D4281F10E537d5b13CA80bE22362310b2bf9",
-        "totalSupply": 3286266662377998272371412582,
-        "totalStaked": 2053411603604779027442962576,
-        "totalStakedInUSD": 480564.4612233689,
-        "totalRewardRate": 24925.09090909091,
+        "totalSupply": 3449552267111526479420034856,
+        "totalStaked": 2087564322191750132612261306,
+        "totalStakedInUSD": 594255.9304385259,
+        "totalRewardRate": 23957.126213592237,
         "allocPoint": 4,
-        "apr": 8.377360370565313,
+        "apr": 6.978916825932102,
         "nonTriAPRs": [
             {
                 "address": "0x9f1F933C660a1DC856F0E0Fe058435879c5CCEf0",
-                "apr": 38.68624458528479
+                "apr": 36.28812841087964
             }
         ],
         "chefVersion": "v2"
@@ -496,16 +496,16 @@
         "id": 31,
         "poolId": 24,
         "lpAddress": "0x1e0e812FBcd3EB75D8562AD6F310Ed94D258D008",
-        "totalSupply": 300796985656259025401938695,
-        "totalStaked": 105857326950337553062181875,
-        "totalStakedInUSD": 484618.1760361964,
-        "totalRewardRate": 74775.27272727274,
+        "totalSupply": 316828628501094611976720873,
+        "totalStaked": 118737078767377799256074114,
+        "totalStakedInUSD": 714927.2079320939,
+        "totalRewardRate": 71871.3786407767,
         "allocPoint": 12,
-        "apr": 24.921857280817477,
+        "apr": 17.402874023398272,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 54.88190016130023
+                "apr": 50.242305756793904
             }
         ],
         "chefVersion": "v2"
@@ -514,16 +514,16 @@
         "id": 32,
         "poolId": 25,
         "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
-        "totalSupply": 1716018199606673270598,
-        "totalStaked": 1689899864445427803447,
-        "totalStakedInUSD": 7598514.067432006,
-        "totalRewardRate": 261713.45454545456,
+        "totalSupply": 1630523950311661362458,
+        "totalStaked": 1605435804153795054667,
+        "totalStakedInUSD": 8207751.536949127,
+        "totalRewardRate": 251549.82524271845,
         "allocPoint": 42,
-        "apr": 5.563133421994265,
+        "apr": 5.305503983443406,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 3.500258881873544
+                "apr": 4.376301014117537
             }
         ],
         "chefVersion": "v2"
@@ -532,16 +532,16 @@
         "id": 33,
         "poolId": 26,
         "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
-        "totalSupply": 1076031432744004897010,
-        "totalStaked": 1037314624585687388685,
-        "totalStakedInUSD": 4818156.07216977,
-        "totalRewardRate": 261713.45454545456,
+        "totalSupply": 1067557381841407631989,
+        "totalStaked": 1033956355486145705679,
+        "totalStakedInUSD": 5460618.779072495,
+        "totalRewardRate": 251549.82524271845,
         "allocPoint": 42,
-        "apr": 8.773386941570855,
+        "apr": 7.974601457491565,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 5.520113079606526
+                "apr": 6.577934264965537
             }
         ],
         "chefVersion": "v2"
@@ -550,16 +550,16 @@
         "id": 34,
         "poolId": 27,
         "lpAddress": "0x29C160d2EF4790F9A23B813e7544D99E539c28Ba",
-        "totalSupply": 37205204386112337881430569,
-        "totalStaked": 37194498525675482586440214,
-        "totalStakedInUSD": 28454.09636446928,
+        "totalSupply": 38934510286608093596958815,
+        "totalStaked": 38921643738007782462679448,
+        "totalStakedInUSD": 35387.10268354295,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xE4eB03598f4DCAB740331fa432f4b85FF58AA97E",
-                "apr": 186.38625403531603
+                "apr": 156.30712360935067
             }
         ],
         "chefVersion": "v2"
@@ -568,16 +568,16 @@
         "id": 35,
         "poolId": 28,
         "lpAddress": "0x87BCC091d0A7F9352728100268Ac8D25729113bB",
-        "totalSupply": 1393297758149846273358621,
-        "totalStaked": 1311800465398351314482299,
-        "totalStakedInUSD": 1318430.4597432734,
-        "totalRewardRate": 24925.09090909091,
-        "allocPoint": 4,
-        "apr": 3.0535259885748114,
+        "totalSupply": 2353454579800467089482941,
+        "totalStaked": 2295721417827922280928736,
+        "totalStakedInUSD": 2308215.6027372857,
+        "totalRewardRate": 71871.3786407767,
+        "allocPoint": 12,
+        "apr": 5.390219232894675,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 10.085719126404417
+                "apr": 7.780191278691187
             }
         ],
         "chefVersion": "v2"
@@ -586,16 +586,16 @@
         "id": 36,
         "poolId": 29,
         "lpAddress": "0x6a29e635BCaB8aBeE1491059728e3D6D11d6A114",
-        "totalSupply": 1024835039740441880235354532,
-        "totalStaked": 1024684270333471050797592183,
-        "totalStakedInUSD": 188008.91144338003,
+        "totalSupply": 1020834060295457318221900913,
+        "totalStaked": 1020667854459753079680238496,
+        "totalStakedInUSD": 233269.9149364706,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x34F291934b88c7870B7A17835B926B264fc13a81",
-                "apr": 46.910223413943804
+                "apr": 46.03600254185385
             }
         ],
         "chefVersion": "v2"
@@ -604,16 +604,16 @@
         "id": 37,
         "poolId": 30,
         "lpAddress": "0x120e713AD36eCBff171FC8B7cf19FA8B6f6Ba50C",
-        "totalSupply": 88323038757774189772796180,
-        "totalStaked": 88249472286663327256581651,
-        "totalStakedInUSD": 68223.8607407335,
-        "totalRewardRate": 12462.545454545456,
+        "totalSupply": 113380842377604095043606777,
+        "totalStaked": 113332782356403608868454245,
+        "totalStakedInUSD": 102381.77302615477,
+        "totalRewardRate": 11978.563106796119,
         "allocPoint": 2,
-        "apr": 29.504792232837207,
+        "apr": 20.253911361682967,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 137.96387195694132
+                "apr": 109.89078035477363
             }
         ],
         "chefVersion": "v2"
@@ -622,16 +622,16 @@
         "id": 38,
         "poolId": 31,
         "lpAddress": "0x71dBEB011EAC90C51b42854A77C45C1E53242698",
-        "totalSupply": 55503894508033313277962056,
-        "totalStaked": 55137198521688654302444809,
-        "totalStakedInUSD": 22158.698883034755,
-        "totalRewardRate": 24925.09090909091,
+        "totalSupply": 117643218345987352879054535,
+        "totalStaked": 113359935601627419389676462,
+        "totalStakedInUSD": 54529.49233077295,
+        "totalRewardRate": 23957.126213592237,
         "allocPoint": 4,
-        "apr": 181.68312562959284,
+        "apr": 76.05540661721724,
         "nonTriAPRs": [
             {
                 "address": "0x0240aE04c9F47B91Cf47Ca2E7ef44c9De0D385Ac",
-                "apr": 112.83332188141556
+                "apr": 51.32573478849175
             }
         ],
         "chefVersion": "v2"
@@ -640,18 +640,31 @@
         "id": 39,
         "poolId": 32,
         "lpAddress": "0xffb69779f14E851A8c550Bf5bB1933c44BBDE129",
-        "totalSupply": 1328571660457017442831545,
-        "totalStaked": 1298706934775147790294556,
-        "totalStakedInUSD": 1298804.90678668,
-        "totalRewardRate": 74775.27272727274,
+        "totalSupply": 1982952528709620508986148,
+        "totalStaked": 1953090738765554500136742,
+        "totalStakedInUSD": 1953290.8985783486,
+        "totalRewardRate": 71871.3786407767,
         "allocPoint": 12,
-        "apr": 9.298998606915358,
+        "apr": 6.369654486486125,
         "nonTriAPRs": [
             {
                 "address": "0xd80d8688b02B3FD3afb81cDb124F188BB5aD0445",
-                "apr": 8.958047634294404
+                "apr": 9.467782472889098
             }
         ],
+        "chefVersion": "v2"
+    },
+    {
+        "id": 40,
+        "poolId": 33,
+        "lpAddress": "0xA36DF7c571bEbA7B3fB89F25dFc990EAC75F525A",
+        "totalSupply": 2510741275683523903384,
+        "totalStaked": 0,
+        "totalStakedInUSD": 0.0,
+        "totalRewardRate": 0.0,
+        "allocPoint": 0,
+        "apr": 0,
+        "nonTriAPRs": [],
         "chefVersion": "v2"
     }
 ]

--- a/utils/rewarder_configs.py
+++ b/utils/rewarder_configs.py
@@ -1,0 +1,52 @@
+import requests
+from retry import retry
+from web3 import Web3
+
+from utils.constants import ZERO_ADDRESS
+
+REWARDER_CONFIG_ENDPOINT = "https://raw.githubusercontent.com/trisolaris-labs/trisolaris_core/main/rewarderConfigs.json"
+
+
+@retry((Exception), delay=10, tries=5)
+def getRewarderConfigs():
+    rewarder_configs = []
+    try:
+        rewarder_configs = requests.get(REWARDER_CONFIG_ENDPOINT).json()
+    except Exception as e:
+        raise e
+
+    return rewarder_configs
+
+
+def formatRewarderConfigItem(rewarder_config_item):
+    rewarder = _getOptionalValueFromRewarderConfigItem(
+        rewarder_config_item, "Rewarder", ZERO_ADDRESS
+    )
+    coingecko_token_name = _getOptionalValueFromRewarderConfigItem(
+        rewarder_config_item, "CoingeckoRewarderTokenName"
+    )
+    rewarder_price_lp = _getOptionalValueFromRewarderConfigItem(
+        rewarder_config_item, "RewarderPriceLP"
+    )
+
+    id = rewarder_config_item["PoolId"]
+    pool = {
+        "LP": Web3.toChecksumAddress(rewarder_config_item["LPToken"]),
+        "LPType": "",
+        "Rewarder": rewarder,
+        "CoingeckoRewarderTokenName": coingecko_token_name,
+        "RewarderPriceLP": rewarder_price_lp,
+        "RewarderTokenDecimals": rewarder_config_item["RewardTokenDecimals"],
+    }
+
+    return (id, pool)
+
+
+def _getOptionalValueFromRewarderConfigItem(rewarder_config_item, key, fallback=""):
+    if key not in rewarder_config_item:
+        return fallback
+
+    if rewarder_config_item[key] is None or "":
+        return fallback
+
+    return rewarder_config_item[key]


### PR DESCRIPTION
- Created `rewarder_configs.py`
  - Fetches configs from `https://raw.githubusercontent.com/trisolaris-labs/trisolaris_core/main/rewarderConfigs.json`
- Added an additional for-loop to iterate through the fetched configs
- Ran `python3 apr.py` to update `datav2.json`