### PR TITLE
Added reference tokens and virtual price normalization

### DIFF
--- a/abi/au_erc20.json
+++ b/abi/au_erc20.json
@@ -1,0 +1,590 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "underlying_", "type": "address" },
+      { "internalType": "contract ComptrollerInterface", "name": "comptroller_", "type": "address" },
+      { "internalType": "contract InterestRateModel", "name": "interestRateModel_", "type": "address" },
+      { "internalType": "uint256", "name": "initialExchangeRateMantissa_", "type": "uint256" },
+      { "internalType": "string", "name": "name_", "type": "string" },
+      { "internalType": "string", "name": "symbol_", "type": "string" },
+      { "internalType": "uint8", "name": "decimals_", "type": "uint8" },
+      { "internalType": "address payable", "name": "admin_", "type": "address" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "BadInput", "type": "error" },
+  { "inputs": [], "name": "InvalidAccountPair", "type": "error" },
+  { "inputs": [], "name": "InvalidCloseAmountRequested", "type": "error" },
+  { "inputs": [], "name": "MarketNotFresh", "type": "error" },
+  { "inputs": [], "name": "TokenInsufficientCash", "type": "error" },
+  { "inputs": [], "name": "Unauthorized", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "cashPrior", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "interestAccumulated", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowIndex", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "AccrueInterest",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "owner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "spender", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "borrowAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "liquidator", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "address", "name": "auTokenCollateral", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "minter", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "mintAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "mintTokens", "type": "uint256" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newAdmin", "type": "address" }
+    ],
+    "name": "NewAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract ComptrollerInterface",
+        "name": "oldComptroller",
+        "type": "address"
+      },
+      { "indexed": false, "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "oldPendingAdmin", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "newPendingAdmin", "type": "address" }
+    ],
+    "name": "NewPendingAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldProtocolSeizeShareMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newProtocolSeizeShareMantissa", "type": "uint256" }
+    ],
+    "name": "NewProtocolSeizeShare",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "oldReserveFactorMantissa", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "redeemer", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "payer", "type": "address" },
+      { "indexed": false, "internalType": "address", "name": "borrower", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "accountBorrows", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "totalBorrows", "type": "uint256" }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "benefactor", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "addAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "admin", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "reduceAmount", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "newTotalReserves", "type": "uint256" }
+    ],
+    "name": "ReservesReduced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  { "inputs": [], "name": "_acceptAdmin", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "addAmount", "type": "uint256" }],
+    "name": "_addReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "reduceAmount", "type": "uint256" }],
+    "name": "_reduceReserves",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract ComptrollerInterface", "name": "newComptroller", "type": "address" }],
+    "name": "_setComptroller",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract InterestRateModel", "name": "newInterestRateModel", "type": "address" }],
+    "name": "_setInterestRateModel",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address payable", "name": "newPendingAdmin", "type": "address" }],
+    "name": "_setPendingAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newProtocolSeizeShareMantissa", "type": "uint256" }],
+    "name": "_setProtocolSeizeShare",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "newReserveFactorMantissa", "type": "uint256" }],
+    "name": "_setReserveFactor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrualBlockTimestamp",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "inputs": [], "name": "accrueInterest", "outputs": [], "stateMutability": "nonpayable", "type": "function" },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "owner", "type": "address" },
+      { "internalType": "address", "name": "spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "spender", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }],
+    "name": "balanceOfUnderlying",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "borrowAmount", "type": "uint256" }],
+    "name": "borrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "borrowBalanceStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowIndex",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowRatePerTimestamp",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "contract ComptrollerInterface", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeRateStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getAccountSnapshot",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getBorrowDataOfAccount",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "account", "type": "address" }],
+    "name": "getSupplyDataOfOneAccount",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "account1", "type": "address" },
+      { "internalType": "address", "name": "account2", "type": "address" }
+    ],
+    "name": "getSupplyDataOfTwoAccount",
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "uint256", "name": "", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [{ "internalType": "contract InterestRateModel", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAuToken",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" },
+      { "internalType": "contract AuTokenInterface", "name": "auTokenCollateral", "type": "address" }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "mintAmount", "type": "uint256" }],
+    "name": "mint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [{ "internalType": "address payable", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolSeizeShareMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemTokens", "type": "uint256" }],
+    "name": "redeem",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "redeemAmount", "type": "uint256" }],
+    "name": "redeemUnderlying",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "repayAmount", "type": "uint256" }],
+    "name": "repayBorrow",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "repayAmount", "type": "uint256" }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "liquidator", "type": "address" },
+      { "internalType": "address", "name": "borrower", "type": "address" },
+      { "internalType": "uint256", "name": "seizeTokens", "type": "uint256" }
+    ],
+    "name": "seize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "supplyRatePerTimestamp",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "contract EIP20NonStandardInterface", "name": "token", "type": "address" }],
+    "name": "sweepToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalReserves",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transfer",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "src", "type": "address" },
+      { "internalType": "address", "name": "dst", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferFrom",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "underlying",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/apr_base.py
+++ b/apr_base.py
@@ -1,3 +1,4 @@
+from gcc_utils import gccPrint
 from utils.node import (
     w3,
     init_chef,
@@ -13,6 +14,7 @@ from utils.reserves import (
 from utils.constants import (
     V1_POOLS,
     V2_POOLS,
+    V2_STABLEPOOL_METADATA,
     WETH_ADDRESS,
     WNEAR_ADDRESS,
     WNEAR_USDC,
@@ -24,7 +26,7 @@ from utils.rewarder_configs import formatRewarderConfigItem, getRewarderConfigs
 
 
 def apr_base():
-    print("Starting APR BASE")
+    gccPrint("Starting APR BASE")
     data = []
 
     ## chef data
@@ -53,7 +55,7 @@ def apr_base():
     triUsdRatio = getDexTokenUSDRatio(w3, WNEAR_TRI, TRI_ADDRESS, wnearUsdRatio)
 
     for id, address in V1_POOLS.items():
-        print("V1 Reached here", address)
+        gccPrint(f"V1 Reached here {address}")
         # Chef V1
         data.append(
             getDataV1Pools(
@@ -71,7 +73,7 @@ def apr_base():
         )
 
     for id, pool in V2_POOLS.items():
-        print(f"V2 Reached here {id}: {pool['LP']}")
+        gccPrint(f"V2 Reached here {id}: {pool['LP']}")
         data.append(
             getDataV2Pools(
                 w3,
@@ -89,7 +91,11 @@ def apr_base():
     fetched_rewarder_configs = getRewarderConfigs()
     for rewarder_config in fetched_rewarder_configs:
         id, pool = formatRewarderConfigItem(rewarder_config)
-        print(f"Fetched V2 Reached here {id}: {pool['LP']}")
+        gccPrint(f"Fetched V2 Reached here {id}: {pool['LP']}")
+
+        if pool["LPType"] == "StableAMM" and (id in V2_STABLEPOOL_METADATA) is False:
+            gccPrint(f"Skipping pool ID {id}: ID Not Found in V2_STABLEPOOL_METADATA")
+            continue
 
         data.append(
             getDataV2Pools(

--- a/datav2.json
+++ b/datav2.json
@@ -3,12 +3,12 @@
         "id": 0,
         "poolId": 0,
         "lpAddress": "0x63da4DB6Ef4e7C62168aB03982399F9588fCd198",
-        "totalSupply": 5540356030449263731293723,
-        "totalStaked": 5273876535228918246651747,
-        "totalStakedInUSD": 858522.80092478,
+        "totalSupply": 6825216433284050615279656,
+        "totalStaked": 6553229140208170380600960,
+        "totalStakedInUSD": 1079202.7550784536,
         "totalRewardRate": 228880.73394495415,
         "allocPoint": 11,
-        "apr": 31.45089786761505,
+        "apr": 24.645639381451097,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -16,9 +16,9 @@
         "id": 1,
         "poolId": 1,
         "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
-        "totalSupply": 550009238822750983363,
+        "totalSupply": 550006875086273152930,
         "totalStaked": 20734497105938732568,
-        "totalStakedInUSD": 98715.41403164921,
+        "totalStakedInUSD": 98726.40730067063,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -29,9 +29,9 @@
         "id": 2,
         "poolId": 2,
         "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
-        "totalSupply": 438937465863934404836,
+        "totalSupply": 438886712892735959100,
         "totalStaked": 31294566847643752032,
-        "totalStakedInUSD": 152943.74893914475,
+        "totalStakedInUSD": 152839.72083883794,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -42,12 +42,12 @@
         "id": 3,
         "poolId": 3,
         "lpAddress": "0x2fe064B6c7D274082aa5d2624709bC9AE7D16C77",
-        "totalSupply": 2325692763530,
-        "totalStaked": 2217160109876,
-        "totalStakedInUSD": 4611727.106142174,
+        "totalSupply": 2325745418461,
+        "totalStaked": 2217213123501,
+        "totalStakedInUSD": 4611117.142342939,
         "totalRewardRate": 104036.69724770643,
         "allocPoint": 5,
-        "apr": 2.6613292105351176,
+        "apr": 2.621888983443886,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -55,12 +55,12 @@
         "id": 4,
         "poolId": 4,
         "lpAddress": "0xbc8A244e8fb683ec1Fd6f88F3cc6E565082174Eb",
-        "totalSupply": 38347318022286110672,
-        "totalStaked": 38302565561464809302,
-        "totalStakedInUSD": 2147729.771031188,
+        "totalSupply": 37884221513880374119,
+        "totalStaked": 37839469725627006056,
+        "totalStakedInUSD": 2144876.635837564,
         "totalRewardRate": 228880.73394495415,
         "allocPoint": 11,
-        "apr": 12.572025258065842,
+        "apr": 12.400546249013434,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -68,12 +68,12 @@
         "id": 5,
         "poolId": 5,
         "lpAddress": "0x84b123875F0F36B966d0B6Ca14b31121bd9676AD",
-        "totalSupply": 610673346700799723952187826,
-        "totalStaked": 365752091813536624626141506,
-        "totalStakedInUSD": 865994.1667640735,
+        "totalSupply": 608938322694286240918931541,
+        "totalStaked": 364017412620583636367178268,
+        "totalStakedInUSD": 855084.1468473555,
         "totalRewardRate": 457761.4678899083,
         "allocPoint": 22,
-        "apr": 62.35911040786524,
+        "apr": 62.2105836465241,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -81,9 +81,9 @@
         "id": 6,
         "poolId": 6,
         "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
-        "totalSupply": 3042000378952750628373,
+        "totalSupply": 3036777654008985990343,
         "totalStaked": 23154754023999468509,
-        "totalStakedInUSD": 1815.457319161659,
+        "totalStakedInUSD": 1869.5336607585718,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -94,12 +94,12 @@
         "id": 7,
         "poolId": 0,
         "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
-        "totalSupply": 3042000378952750628373,
-        "totalStaked": 2973259511778452067200,
-        "totalStakedInUSD": 233119.5458535412,
+        "totalSupply": 3036777654008985990343,
+        "totalStaked": 2968044570979276812056,
+        "totalStakedInUSD": 239642.3311742463,
         "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 11.699599604005124,
+        "apr": 11.211001344877461,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -112,12 +112,12 @@
         "id": 8,
         "poolId": 1,
         "lpAddress": "0xd1654a7713617d41A8C9530Fb9B948d00e162194",
-        "totalSupply": 761290193852255208592747,
-        "totalStaked": 752186143725475685724556,
-        "totalStakedInUSD": 243712.44951302555,
+        "totalSupply": 760411908804525448706995,
+        "totalStaked": 751303552522164838898657,
+        "totalStakedInUSD": 247732.16921071673,
         "totalRewardRate": 98256.88073394496,
         "allocPoint": 17,
-        "apr": 47.56208698064374,
+        "apr": 46.090823202274905,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -132,7 +132,7 @@
         "lpAddress": "0xdF8CbF89ad9b7dAFdd3e37acEc539eEcC8c47914",
         "totalSupply": 1989268428920229837609987,
         "totalStaked": 1465111139910232586320812,
-        "totalStakedInUSD": 149.96604313226106,
+        "totalStakedInUSD": 149.82522495403347,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -150,7 +150,7 @@
         "lpAddress": "0xa9eded3E339b9cd92bB6DEF5c5379d678131fF90",
         "totalSupply": 49517891751419580350542546,
         "totalStaked": 34846716439790700839961288,
-        "totalStakedInUSD": 28251.92571666206,
+        "totalStakedInUSD": 28616.560678446447,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -166,12 +166,12 @@
         "id": 11,
         "poolId": 4,
         "lpAddress": "0x61C9E05d1Cdb1b70856c7a2c53fA9c220830633c",
-        "totalSupply": 73815028057984968,
-        "totalStaked": 72915731036152252,
-        "totalStakedInUSD": 521343.2527734675,
+        "totalSupply": 72712800530026351,
+        "totalStaked": 71813736820710464,
+        "totalStakedInUSD": 508881.03279070515,
         "totalRewardRate": 242752.29357798165,
         "allocPoint": 42,
-        "apr": 54.9307121255869,
+        "apr": 55.434607308275645,
         "nonTriAPRs": [],
         "chefVersion": "v2"
     },
@@ -181,7 +181,7 @@
         "lpAddress": "0x6443532841a5279cb04420E61Cf855cBEb70dc8C",
         "totalSupply": 388342958854078436447595,
         "totalStaked": 276081191534149124800711,
-        "totalStakedInUSD": 4760.407786318917,
+        "totalStakedInUSD": 4778.424100193313,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -194,7 +194,7 @@
         "lpAddress": "0x7be4a49AA41B34db70e539d4Ae43c7fBDf839DfA",
         "totalSupply": 2229360188505413949378,
         "totalStaked": 1281331265594686716048,
-        "totalStakedInUSD": 92.03291965121876,
+        "totalStakedInUSD": 91.17647164698374,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -207,7 +207,7 @@
         "lpAddress": "0x3dC236Ea01459F57EFc737A12BA3Bb5F3BFfD071",
         "totalSupply": 748541183994895295483989,
         "totalStaked": 427493138825209133119227,
-        "totalStakedInUSD": 1386.001402185834,
+        "totalStakedInUSD": 1384.7675098449386,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -218,16 +218,16 @@
         "id": 15,
         "poolId": 8,
         "lpAddress": "0x48887cEEA1b8AD328d5254BeF774Be91B90FaA09",
-        "totalSupply": 422873313427897202180974111,
-        "totalStaked": 279685618616149665299884376,
-        "totalStakedInUSD": 214221.29690411894,
+        "totalSupply": 422851319069647504693280284,
+        "totalStaked": 279663935235254680895493902,
+        "totalStakedInUSD": 213299.82933692055,
         "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 12.731718954977085,
+        "apr": 12.595558587345808,
         "nonTriAPRs": [
             {
                 "address": "0xea62791aa682d455614eaA2A12Ba3d9A2fD197af",
-                "apr": 22.35508408409752
+                "apr": 21.29193731129671
             }
         ],
         "chefVersion": "v2"
@@ -238,7 +238,7 @@
         "lpAddress": "0xd62f9ec4C4d323A0C111d5e78b77eA33A2AA862f",
         "totalSupply": 14879132067443280723801871,
         "totalStaked": 9929398434662714706977261,
-        "totalStakedInUSD": 555.659234911697,
+        "totalStakedInUSD": 555.1374706539938,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -254,16 +254,16 @@
         "id": 17,
         "poolId": 10,
         "lpAddress": "0xdDAdf88b007B95fEb42DDbd110034C9a8e9746F2",
-        "totalSupply": 356143846734532939190217229,
-        "totalStaked": 23588666562281709654856029,
-        "totalStakedInUSD": 9421.435531134444,
+        "totalSupply": 355588620282633197486320351,
+        "totalStaked": 23034003154864927558448511,
+        "totalStakedInUSD": 9192.072398791346,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x501acE9c35E60f03A2af4d484f49F9B1EFde9f40",
-                "apr": 2742.1089474362307
+                "apr": 2755.455632717725
             }
         ],
         "chefVersion": "v2"
@@ -272,9 +272,9 @@
         "id": 18,
         "poolId": 11,
         "lpAddress": "0x5913f644A10d98c79F2e0b609988640187256373",
-        "totalSupply": 15628537183783692114483433,
+        "totalSupply": 15628537414370390264730557,
         "totalStaked": 13155784445874582950972343,
-        "totalStakedInUSD": 9213.12842717871,
+        "totalStakedInUSD": 9074.212561298482,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -290,16 +290,16 @@
         "id": 19,
         "poolId": 12,
         "lpAddress": "0x47924Ae4968832984F4091EEC537dfF5c38948a4",
-        "totalSupply": 68360448262677260224096910594,
-        "totalStaked": 65946267775333623072660485281,
-        "totalStakedInUSD": 525384.8496797592,
+        "totalSupply": 67004168722553336451478893417,
+        "totalStaked": 64589496201100939255194063124,
+        "totalStakedInUSD": 514147.0323717285,
         "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 5.191252370555404,
+        "apr": 5.2254128253756225,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 2.0124909759476344
+                "apr": 2.3158873593283698
             }
         ],
         "chefVersion": "v2"
@@ -308,16 +308,16 @@
         "id": 20,
         "poolId": 13,
         "lpAddress": "0xb419ff9221039Bdca7bb92A131DD9CF7DEb9b8e5",
-        "totalSupply": 54876428393738472387811,
-        "totalStaked": 54779423115894604035547,
-        "totalStakedInUSD": 14911.849819022384,
+        "totalSupply": 55070830084477470223390,
+        "totalStaked": 54973637399351853481107,
+        "totalStakedInUSD": 14859.762631273394,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x7cA1C28663b76CFDe424A9494555B94846205585",
-                "apr": 259.395124392692
+                "apr": 217.41168094372463
             }
         ],
         "chefVersion": "v2"
@@ -328,7 +328,7 @@
         "lpAddress": "0xFBc4C42159A5575a772BebA7E3BF91DB508E127a",
         "totalSupply": 263669532102834695244835,
         "totalStaked": 99202934162754423690443,
-        "totalStakedInUSD": 66.18511199313612,
+        "totalStakedInUSD": 67.83472917102038,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -346,7 +346,7 @@
         "lpAddress": "0x7B273238C6DD0453C160f305df35c350a123E505",
         "totalSupply": 7275145860393619,
         "totalStaked": 427906915270007,
-        "totalStakedInUSD": 501.9925075857948,
+        "totalStakedInUSD": 502.78512917121066,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -362,16 +362,16 @@
         "id": 23,
         "poolId": 16,
         "lpAddress": "0x6277f94a69Df5df0Bc58b25917B9ECEFBf1b846A",
-        "totalSupply": 353853348349,
-        "totalStaked": 180453863486,
-        "totalStakedInUSD": 34908.91877809476,
+        "totalSupply": 353853361868,
+        "totalStaked": 180453877005,
+        "totalStakedInUSD": 34908.92273392767,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
-                "apr": 126.0295444045912
+                "apr": 125.91118834074967
             }
         ],
         "chefVersion": "v2"
@@ -380,16 +380,16 @@
         "id": 24,
         "poolId": 17,
         "lpAddress": "0xadAbA7E2bf88Bd10ACb782302A568294566236dC",
-        "totalSupply": 45147974708663301403988318,
-        "totalStaked": 43717882434054844997476743,
-        "totalStakedInUSD": 3805.3388757194757,
+        "totalSupply": 45228179495796160605529462,
+        "totalStaked": 43797743731749286600339620,
+        "totalStakedInUSD": 3756.972490803904,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x4148d2Ce7816F0AE378d98b40eB3A7211E1fcF0D",
-                "apr": 34.422766858424374
+                "apr": 33.89187786656021
             }
         ],
         "chefVersion": "v2"
@@ -411,9 +411,9 @@
         "id": 26,
         "poolId": 19,
         "lpAddress": "0x5E74D85311fe2409c341Ce49Ce432BB950D221DE",
-        "totalSupply": 241726122650651238,
+        "totalSupply": 241726568360442946,
         "totalStaked": 232235837926856687,
-        "totalStakedInUSD": 5985.416319288773,
+        "totalStakedInUSD": 5919.410366621085,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -424,16 +424,16 @@
         "id": 27,
         "poolId": 20,
         "lpAddress": "0xbe753E99D0dBd12FB39edF9b884eBF3B1B09f26C",
-        "totalSupply": 14439939001882108105390252,
-        "totalStaked": 9869611484844832370017945,
-        "totalStakedInUSD": 1846.169766717765,
+        "totalSupply": 13840795783173033822727406,
+        "totalStaked": 9321318233608353730084284,
+        "totalStakedInUSD": 1649.15242651296,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
-                "apr": 189.03636894283764
+                "apr": 187.51091672861628
             }
         ],
         "chefVersion": "v2"
@@ -442,16 +442,16 @@
         "id": 28,
         "poolId": 21,
         "lpAddress": "0xbC0e71aE3Ef51ae62103E003A9Be2ffDe8421700",
-        "totalSupply": 284873318038756769587666,
-        "totalStaked": 274687157113286902579156,
-        "totalStakedInUSD": 1051.1352579575566,
+        "totalSupply": 275893156480691424229654,
+        "totalStaked": 265609930720746494569834,
+        "totalStakedInUSD": 1030.6186006372334,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
-                "apr": 332.01552941007304
+                "apr": 300.0470621522522
             }
         ],
         "chefVersion": "v2"
@@ -460,16 +460,16 @@
         "id": 29,
         "poolId": 22,
         "lpAddress": "0xbceA13f9125b0E3B66e979FedBCbf7A4AfBa6fd1",
-        "totalSupply": 30814572089319721160216473723,
+        "totalSupply": 30772707552467478653055133417,
         "totalStaked": 5107006920788173001364121768,
-        "totalStakedInUSD": 38465.345666927045,
+        "totalStakedInUSD": 38428.55033534327,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x918dBe087040A41b786f0Da83190c293DAe24749",
-                "apr": 109.83005649921269
+                "apr": 109.82817604275779
             }
         ],
         "chefVersion": "v2"
@@ -478,16 +478,16 @@
         "id": 30,
         "poolId": 23,
         "lpAddress": "0xBBf3D4281F10E537d5b13CA80bE22362310b2bf9",
-        "totalSupply": 2613395329989109994568318970,
-        "totalStaked": 1363594625947236111092052143,
-        "totalStakedInUSD": 245535.21331252242,
+        "totalSupply": 2579552046796519120595836133,
+        "totalStaked": 1325256773772257322497864105,
+        "totalStakedInUSD": 236764.64988916583,
         "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 11.108000801833851,
+        "apr": 11.347261925890159,
         "nonTriAPRs": [
             {
                 "address": "0x9f1F933C660a1DC856F0E0Fe058435879c5CCEf0",
-                "apr": 26.042812563440926
+                "apr": 26.60912424542625
             }
         ],
         "chefVersion": "v2"
@@ -496,12 +496,12 @@
         "id": 31,
         "poolId": 24,
         "lpAddress": "0x1e0e812FBcd3EB75D8562AD6F310Ed94D258D008",
-        "totalSupply": 243277997910963342631807696,
-        "totalStaked": 48761352268900837537651462,
-        "totalStakedInUSD": 204797.57054068104,
+        "totalSupply": 242777412739052175095642878,
+        "totalStaked": 48262337446779812150760145,
+        "totalStakedInUSD": 207731.721407111,
         "totalRewardRate": 69357.7981651376,
         "allocPoint": 12,
-        "apr": 39.9527006959124,
+        "apr": 38.799521982761725,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -514,12 +514,12 @@
         "id": 32,
         "poolId": 25,
         "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
-        "totalSupply": 550009238822750983363,
-        "totalStaked": 527927659593696852843,
-        "totalStakedInUSD": 2513424.7157904203,
+        "totalSupply": 550006875086273152930,
+        "totalStaked": 527934313736935333787,
+        "totalStakedInUSD": 2513736.302341488,
         "totalRewardRate": 242752.29357798165,
         "allocPoint": 42,
-        "apr": 11.393918408139168,
+        "apr": 11.222187543341702,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -532,12 +532,12 @@
         "id": 33,
         "poolId": 26,
         "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
-        "totalSupply": 438937465863934404836,
-        "totalStaked": 406660145634221171594,
-        "totalStakedInUSD": 1987441.930876283,
+        "totalSupply": 438886712892735959100,
+        "totalStaked": 406611993704993669984,
+        "totalStakedInUSD": 1985854.7303163495,
         "totalRewardRate": 242752.29357798165,
         "allocPoint": 42,
-        "apr": 14.40935490582598,
+        "apr": 14.205278859893568,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -550,16 +550,16 @@
         "id": 34,
         "poolId": 27,
         "lpAddress": "0x29C160d2EF4790F9A23B813e7544D99E539c28Ba",
-        "totalSupply": 45710270605175552335656451,
-        "totalStaked": 45688108598787246773473104,
-        "totalStakedInUSD": 32947.7250804246,
+        "totalSupply": 48543826840577318865038123,
+        "totalStaked": 48520868708559314009311361,
+        "totalStakedInUSD": 37034.287642747026,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xE4eB03598f4DCAB740331fa432f4b85FF58AA97E",
-                "apr": 152.1551332531452
+                "apr": 132.54001032818502
             }
         ],
         "chefVersion": "v2"
@@ -568,16 +568,16 @@
         "id": 35,
         "poolId": 28,
         "lpAddress": "0x87BCC091d0A7F9352728100268Ac8D25729113bB",
-        "totalSupply": 9403255719952580725001075,
-        "totalStaked": 9302023948591103503886691,
-        "totalStakedInUSD": 9332698.66891333,
+        "totalSupply": 9848624599865610284569747,
+        "totalStaked": 9745804730915771937802339,
+        "totalStakedInUSD": 9778114.397592677,
         "totalRewardRate": 69357.7981651376,
         "allocPoint": 12,
-        "apr": 0.8767256213164061,
+        "apr": 0.8242787068677008,
         "nonTriAPRs": [
             {
                 "address": "0x5183e1B1091804BC2602586919E6880ac1cf2896",
-                "apr": 12.684247525778474
+                "apr": 12.106450710900265
             }
         ],
         "chefVersion": "v2"
@@ -588,14 +588,14 @@
         "lpAddress": "0x6a29e635BCaB8aBeE1491059728e3D6D11d6A114",
         "totalSupply": 1014970700380295855996380594,
         "totalStaked": 1014695150731204245132293941,
-        "totalStakedInUSD": 151474.19350135094,
+        "totalStakedInUSD": 155681.98620317192,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x34F291934b88c7870B7A17835B926B264fc13a81",
-                "apr": 36.45627567987902
+                "apr": 37.50104311290843
             }
         ],
         "chefVersion": "v2"
@@ -604,16 +604,16 @@
         "id": 37,
         "poolId": 30,
         "lpAddress": "0x120e713AD36eCBff171FC8B7cf19FA8B6f6Ba50C",
-        "totalSupply": 92127908343823699383447117,
-        "totalStaked": 92122789030377939889796584,
-        "totalStakedInUSD": 63528.328399190344,
+        "totalSupply": 92177172090635549772701529,
+        "totalStaked": 92172085204554441493448949,
+        "totalStakedInUSD": 62845.79945205017,
         "totalRewardRate": 11559.633027522936,
         "allocPoint": 2,
-        "apr": 21.46605628607021,
+        "apr": 21.374781771484024,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 64.70983834838346
+                "apr": 73.66390995021824
             }
         ],
         "chefVersion": "v2"
@@ -622,16 +622,16 @@
         "id": 38,
         "poolId": 31,
         "lpAddress": "0x71dBEB011EAC90C51b42854A77C45C1E53242698",
-        "totalSupply": 137656296553481791838637839,
-        "totalStaked": 133142916482326022458421683,
-        "totalStakedInUSD": 35488.52201014017,
+        "totalSupply": 138258702879920194359792207,
+        "totalStaked": 135018973637529291486612491,
+        "totalStakedInUSD": 32242.50768038532,
         "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 76.8531680630329,
+        "apr": 83.32573023525875,
         "nonTriAPRs": [
             {
                 "address": "0x0240aE04c9F47B91Cf47Ca2E7ef44c9De0D385Ac",
-                "apr": 29.033801911048474
+                "apr": 25.6496609401706
             }
         ],
         "chefVersion": "v2"
@@ -640,16 +640,16 @@
         "id": 39,
         "poolId": 32,
         "lpAddress": "0xffb69779f14E851A8c550Bf5bB1933c44BBDE129",
-        "totalSupply": 2616369661050528019303904,
-        "totalStaked": 2583593413674757004850665,
-        "totalStakedInUSD": 2579366.73926604,
+        "totalSupply": 2528514528822564586145992,
+        "totalStaked": 2495738281446793571692753,
+        "totalStakedInUSD": 2489385.3220624016,
         "totalRewardRate": 69357.7981651376,
         "allocPoint": 12,
-        "apr": 3.172180176825142,
+        "apr": 3.237703468330364,
         "nonTriAPRs": [
             {
                 "address": "0xd80d8688b02B3FD3afb81cDb124F188BB5aD0445",
-                "apr": 8.113102471574656
+                "apr": 8.797352425402044
             }
         ],
         "chefVersion": "v2"
@@ -658,12 +658,12 @@
         "id": 40,
         "poolId": 33,
         "lpAddress": "0xA36DF7c571bEbA7B3fB89F25dFc990EAC75F525A",
-        "totalSupply": 81097128117989462375542006,
-        "totalStaked": 81049244022451200881491733,
-        "totalStakedInUSD": 323894.2260666379,
+        "totalSupply": 80002727631683024438123379,
+        "totalStaked": 79950868650661432116574471,
+        "totalStakedInUSD": 318542.35903856985,
         "totalRewardRate": 28899.082568807335,
         "allocPoint": 5,
-        "apr": 10.525833462190253,
+        "apr": 10.542673607023886,
         "nonTriAPRs": [],
         "chefVersion": "v2"
     },
@@ -671,16 +671,16 @@
         "id": 41,
         "poolId": 34,
         "lpAddress": "0x53b65177803993C84F31AF4aE7E52FEB171b3b84",
-        "totalSupply": 1146374235218458284779072,
-        "totalStaked": 772854447031793978330260,
-        "totalStakedInUSD": 137551.7248622425,
+        "totalSupply": 1155906709945919837171041,
+        "totalStaked": 782379652444722798701619,
+        "totalStakedInUSD": 135920.02694272046,
         "totalRewardRate": 34678.8990825688,
         "allocPoint": 6,
-        "apr": 29.742324377452533,
+        "apr": 29.649388955200635,
         "nonTriAPRs": [
             {
                 "address": "0x221292443758F63563a1ed04b547278B05845FCb",
-                "apr": 37.30781045392557
+                "apr": 36.89499744791142
             }
         ],
         "chefVersion": "v2"
@@ -689,16 +689,16 @@
         "id": 42,
         "poolId": 35,
         "lpAddress": "0x25bED9DDD30c21a698ba0654f8Da0F381CA1A67b",
-        "totalSupply": 171547397845685730055011555852,
-        "totalStaked": 171499842509712342391982187298,
-        "totalStakedInUSD": 46105.93842726219,
+        "totalSupply": 171925720469888794768802989185,
+        "totalStaked": 171870892199194421881332540084,
+        "totalStakedInUSD": 49024.572693757385,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 80.26434483667357
+                "apr": 85.00784232736133
             }
         ],
         "chefVersion": "v2"
@@ -707,16 +707,16 @@
         "id": 43,
         "poolId": 36,
         "lpAddress": "0x044b6B0CD3Bb13D2b9057781Df4459C66781dCe7",
-        "totalSupply": 3379628031414345438653321348,
-        "totalStaked": 382911959082873740629324214,
-        "totalStakedInUSD": 48847.79135783789,
+        "totalSupply": 3381549355334598478579381795,
+        "totalStaked": 384896358588930673933080234,
+        "totalStakedInUSD": 50252.14379604541,
         "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 55.834773088800425,
+        "apr": 53.463002652942926,
         "nonTriAPRs": [
             {
                 "address": "0x09C9D464b58d96837f8d8b6f4d9fE4aD408d3A4f",
-                "apr": 42.11561376610639
+                "apr": 41.20635290108758
             }
         ],
         "chefVersion": "v2"

--- a/datav2.json
+++ b/datav2.json
@@ -3,12 +3,12 @@
         "id": 0,
         "poolId": 0,
         "lpAddress": "0x63da4DB6Ef4e7C62168aB03982399F9588fCd198",
-        "totalSupply": 15473552259922524601687067,
-        "totalStaked": 15199561041079870267217693,
-        "totalStakedInUSD": 3694837.320382873,
+        "totalSupply": 5540356030449263731293723,
+        "totalStaked": 5273876535228918246651747,
+        "totalStakedInUSD": 858522.80092478,
         "totalRewardRate": 228880.73394495415,
         "allocPoint": 11,
-        "apr": 21.42768469984481,
+        "apr": 31.45089786761505,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -16,9 +16,9 @@
         "id": 1,
         "poolId": 1,
         "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
-        "totalSupply": 1601814234261947520899,
-        "totalStaked": 23209259345172526870,
-        "totalStakedInUSD": 137690.54768985906,
+        "totalSupply": 550009238822750983363,
+        "totalStaked": 20734497105938732568,
+        "totalStakedInUSD": 98715.41403164921,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -29,9 +29,9 @@
         "id": 2,
         "poolId": 2,
         "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
-        "totalSupply": 1026964009281608038211,
-        "totalStaked": 32279926623252984778,
-        "totalStakedInUSD": 197592.13989267615,
+        "totalSupply": 438937465863934404836,
+        "totalStaked": 31294566847643752032,
+        "totalStakedInUSD": 152943.74893914475,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -42,12 +42,12 @@
         "id": 3,
         "poolId": 3,
         "lpAddress": "0x2fe064B6c7D274082aa5d2624709bC9AE7D16C77",
-        "totalSupply": 2924766059654,
-        "totalStaked": 2816175475463,
-        "totalStakedInUSD": 5866501.069362245,
+        "totalSupply": 2325692763530,
+        "totalStaked": 2217160109876,
+        "totalStakedInUSD": 4611727.106142174,
         "totalRewardRate": 104036.69724770643,
         "allocPoint": 5,
-        "apr": 6.134352578719276,
+        "apr": 2.6613292105351176,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -55,12 +55,12 @@
         "id": 4,
         "poolId": 4,
         "lpAddress": "0xbc8A244e8fb683ec1Fd6f88F3cc6E565082174Eb",
-        "totalSupply": 39562173753890461494,
-        "totalStaked": 39518012716023519216,
-        "totalStakedInUSD": 3164018.431930616,
+        "totalSupply": 38347318022286110672,
+        "totalStaked": 38302565561464809302,
+        "totalStakedInUSD": 2147729.771031188,
         "totalRewardRate": 228880.73394495415,
         "allocPoint": 11,
-        "apr": 25.02254990659923,
+        "apr": 12.572025258065842,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -68,12 +68,12 @@
         "id": 5,
         "poolId": 5,
         "lpAddress": "0x84b123875F0F36B966d0B6Ca14b31121bd9676AD",
-        "totalSupply": 640500649702052321887090585,
-        "totalStaked": 394590136673186588557888417,
-        "totalStakedInUSD": 2013611.0630404905,
+        "totalSupply": 610673346700799723952187826,
+        "totalStaked": 365752091813536624626141506,
+        "totalStakedInUSD": 865994.1667640735,
         "totalRewardRate": 457761.4678899083,
         "allocPoint": 22,
-        "apr": 78.63664495251302,
+        "apr": 62.35911040786524,
         "nonTriAPRs": [],
         "chefVersion": "v1"
     },
@@ -81,9 +81,9 @@
         "id": 6,
         "poolId": 6,
         "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
-        "totalSupply": 3537142497166047539511,
+        "totalSupply": 3042000378952750628373,
         "totalStaked": 23154754023999468509,
-        "totalStakedInUSD": 3122.30112211016,
+        "totalStakedInUSD": 1815.457319161659,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -94,16 +94,16 @@
         "id": 7,
         "poolId": 0,
         "lpAddress": "0x5eeC60F348cB1D661E4A5122CF4638c7DB7A886e",
-        "totalSupply": 3537142497166047539511,
-        "totalStaked": 3470682869786897263080,
-        "totalStakedInUSD": 468003.97912205383,
-        "totalRewardRate": 23555.47862212221,
+        "totalSupply": 3042000378952750628373,
+        "totalStaked": 2973259511778452067200,
+        "totalStakedInUSD": 233119.5458535412,
+        "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 17.4101983493669,
+        "apr": 11.699599604005124,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 22.721272375275095
+                "apr": 0.0
             }
         ],
         "chefVersion": "v2"
@@ -112,16 +112,16 @@
         "id": 8,
         "poolId": 1,
         "lpAddress": "0xd1654a7713617d41A8C9530Fb9B948d00e162194",
-        "totalSupply": 625438876174310698312627,
-        "totalStaked": 620238501322269191532524,
-        "totalStakedInUSD": 500087.42701813986,
-        "totalRewardRate": 100110.78414401939,
+        "totalSupply": 761290193852255208592747,
+        "totalStaked": 752186143725475685724556,
+        "totalStakedInUSD": 243712.44951302555,
+        "totalRewardRate": 98256.88073394496,
         "allocPoint": 17,
-        "apr": 69.24624990457431,
+        "apr": 47.56208698064374,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 21.263573742994794
+                "apr": 0.0
             }
         ],
         "chefVersion": "v2"
@@ -130,9 +130,9 @@
         "id": 9,
         "poolId": 2,
         "lpAddress": "0xdF8CbF89ad9b7dAFdd3e37acEc539eEcC8c47914",
-        "totalSupply": 1990110139366162033281423,
+        "totalSupply": 1989268428920229837609987,
         "totalStaked": 1465111139910232586320812,
-        "totalStakedInUSD": 132.71410587340964,
+        "totalStakedInUSD": 149.96604313226106,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -148,9 +148,9 @@
         "id": 10,
         "poolId": 3,
         "lpAddress": "0xa9eded3E339b9cd92bB6DEF5c5379d678131fF90",
-        "totalSupply": 50881084063807017643162776,
-        "totalStaked": 36177740835365248870346675,
-        "totalStakedInUSD": 35738.48636532769,
+        "totalSupply": 49517891751419580350542546,
+        "totalStaked": 34846716439790700839961288,
+        "totalStakedInUSD": 28251.92571666206,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -166,12 +166,12 @@
         "id": 11,
         "poolId": 4,
         "lpAddress": "0x61C9E05d1Cdb1b70856c7a2c53fA9c220830633c",
-        "totalSupply": 62858494969243900,
-        "totalStaked": 61947636101754916,
-        "totalStakedInUSD": 754088.8071076245,
-        "totalRewardRate": 247332.5255322832,
+        "totalSupply": 73815028057984968,
+        "totalStaked": 72915731036152252,
+        "totalStakedInUSD": 521343.2527734675,
+        "totalRewardRate": 242752.29357798165,
         "allocPoint": 42,
-        "apr": 113.45406707286241,
+        "apr": 54.9307121255869,
         "nonTriAPRs": [],
         "chefVersion": "v2"
     },
@@ -179,9 +179,9 @@
         "id": 12,
         "poolId": 5,
         "lpAddress": "0x6443532841a5279cb04420E61Cf855cBEb70dc8C",
-        "totalSupply": 1420536797092117388501909,
-        "totalStaked": 1163899784224777687044602,
-        "totalStakedInUSD": 33161.83250792502,
+        "totalSupply": 388342958854078436447595,
+        "totalStaked": 276081191534149124800711,
+        "totalStakedInUSD": 4760.407786318917,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -194,7 +194,7 @@
         "lpAddress": "0x7be4a49AA41B34db70e539d4Ae43c7fBDf839DfA",
         "totalSupply": 2229360188505413949378,
         "totalStaked": 1281331265594686716048,
-        "totalStakedInUSD": 129.25600738922984,
+        "totalStakedInUSD": 92.03291965121876,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -205,9 +205,9 @@
         "id": 14,
         "poolId": 7,
         "lpAddress": "0x3dC236Ea01459F57EFc737A12BA3Bb5F3BFfD071",
-        "totalSupply": 749864328663612582877058,
+        "totalSupply": 748541183994895295483989,
         "totalStaked": 427493138825209133119227,
-        "totalStakedInUSD": 2073.63019651673,
+        "totalStakedInUSD": 1386.001402185834,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -218,16 +218,16 @@
         "id": 15,
         "poolId": 8,
         "lpAddress": "0x48887cEEA1b8AD328d5254BeF774Be91B90FaA09",
-        "totalSupply": 423629449945758867124081846,
-        "totalStaked": 280434720583241394437205177,
-        "totalStakedInUSD": 393168.29664010677,
-        "totalRewardRate": 23555.47862212221,
+        "totalSupply": 422873313427897202180974111,
+        "totalStaked": 279685618616149665299884376,
+        "totalStakedInUSD": 214221.29690411894,
+        "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 20.724056782905798,
+        "apr": 12.731718954977085,
         "nonTriAPRs": [
             {
                 "address": "0xea62791aa682d455614eaA2A12Ba3d9A2fD197af",
-                "apr": 22.545181427265117
+                "apr": 22.35508408409752
             }
         ],
         "chefVersion": "v2"
@@ -236,9 +236,9 @@
         "id": 16,
         "poolId": 9,
         "lpAddress": "0xd62f9ec4C4d323A0C111d5e78b77eA33A2AA862f",
-        "totalSupply": 14892858868705209230463066,
-        "totalStaked": 9942432426695922758814344,
-        "totalStakedInUSD": 898.9818260027997,
+        "totalSupply": 14879132067443280723801871,
+        "totalStaked": 9929398434662714706977261,
+        "totalStakedInUSD": 555.659234911697,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -254,16 +254,16 @@
         "id": 17,
         "poolId": 10,
         "lpAddress": "0xdDAdf88b007B95fEb42DDbd110034C9a8e9746F2",
-        "totalSupply": 357000444710485720360397421,
-        "totalStaked": 24656549823812208547124331,
-        "totalStakedInUSD": 14666.200339375057,
+        "totalSupply": 356143846734532939190217229,
+        "totalStaked": 23588666562281709654856029,
+        "totalStakedInUSD": 9421.435531134444,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x501acE9c35E60f03A2af4d484f49F9B1EFde9f40",
-                "apr": 2329.935444118826
+                "apr": 2742.1089474362307
             }
         ],
         "chefVersion": "v2"
@@ -272,9 +272,9 @@
         "id": 18,
         "poolId": 11,
         "lpAddress": "0x5913f644A10d98c79F2e0b609988640187256373",
-        "totalSupply": 18501472245900910452972472,
-        "totalStaked": 16035050851142800101571186,
-        "totalStakedInUSD": 31191.53791420103,
+        "totalSupply": 15628537183783692114483433,
+        "totalStaked": 13155784445874582950972343,
+        "totalStakedInUSD": 9213.12842717871,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -290,16 +290,16 @@
         "id": 19,
         "poolId": 12,
         "lpAddress": "0x47924Ae4968832984F4091EEC537dfF5c38948a4",
-        "totalSupply": 58603413341175797991920489564,
-        "totalStaked": 56206993164083605254100917044,
-        "totalStakedInUSD": 711142.5356058925,
-        "totalRewardRate": 23555.47862212221,
+        "totalSupply": 68360448262677260224096910594,
+        "totalStaked": 65946267775333623072660485281,
+        "totalStakedInUSD": 525384.8496797592,
+        "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 11.457677887128215,
+        "apr": 5.191252370555404,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 2.362216057566797
+                "apr": 2.0124909759476344
             }
         ],
         "chefVersion": "v2"
@@ -308,16 +308,16 @@
         "id": 20,
         "poolId": 13,
         "lpAddress": "0xb419ff9221039Bdca7bb92A131DD9CF7DEb9b8e5",
-        "totalSupply": 48159193932282581347024,
-        "totalStaked": 48097621306180069620446,
-        "totalStakedInUSD": 45147.364843806026,
+        "totalSupply": 54876428393738472387811,
+        "totalStaked": 54779423115894604035547,
+        "totalStakedInUSD": 14911.849819022384,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x7cA1C28663b76CFDe424A9494555B94846205585",
-                "apr": 95.67670107264844
+                "apr": 259.395124392692
             }
         ],
         "chefVersion": "v2"
@@ -326,9 +326,9 @@
         "id": 21,
         "poolId": 14,
         "lpAddress": "0xFBc4C42159A5575a772BebA7E3BF91DB508E127a",
-        "totalSupply": 3026002852181873597275213,
-        "totalStaked": 2861172845259528134946864,
-        "totalStakedInUSD": 2969.652924496126,
+        "totalSupply": 263669532102834695244835,
+        "totalStaked": 99202934162754423690443,
+        "totalStakedInUSD": 66.18511199313612,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -344,9 +344,9 @@
         "id": 22,
         "poolId": 15,
         "lpAddress": "0x7B273238C6DD0453C160f305df35c350a123E505",
-        "totalSupply": 10693913000465417,
+        "totalSupply": 7275145860393619,
         "totalStaked": 427906915270007,
-        "totalStakedInUSD": 661.6320130003475,
+        "totalStakedInUSD": 501.9925075857948,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -362,16 +362,16 @@
         "id": 23,
         "poolId": 16,
         "lpAddress": "0x6277f94a69Df5df0Bc58b25917B9ECEFBf1b846A",
-        "totalSupply": 438509397259,
-        "totalStaked": 265733914536,
-        "totalStakedInUSD": 53162.75864060938,
+        "totalSupply": 353853348349,
+        "totalStaked": 180453863486,
+        "totalStakedInUSD": 34908.91877809476,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xC42C30aC6Cc15faC9bD938618BcaA1a1FaE8501d",
-                "apr": 132.16458070488974
+                "apr": 126.0295444045912
             }
         ],
         "chefVersion": "v2"
@@ -380,16 +380,16 @@
         "id": 24,
         "poolId": 17,
         "lpAddress": "0xadAbA7E2bf88Bd10ACb782302A568294566236dC",
-        "totalSupply": 49531435427279236228775003,
-        "totalStaked": 48492819060356550244870419,
-        "totalStakedInUSD": 10702.057534611276,
+        "totalSupply": 45147974708663301403988318,
+        "totalStaked": 43717882434054844997476743,
+        "totalStakedInUSD": 3805.3388757194757,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x4148d2Ce7816F0AE378d98b40eB3A7211E1fcF0D",
-                "apr": 49.37865226834089
+                "apr": 34.422766858424374
             }
         ],
         "chefVersion": "v2"
@@ -400,7 +400,7 @@
         "lpAddress": "0x5EB99863f7eFE88c447Bc9D52AA800421b1de6c9",
         "totalSupply": 315679430574785832835,
         "totalStaked": 1009954227594396962,
-        "totalStakedInUSD": 1.1097308716216878,
+        "totalStakedInUSD": 1.1064116367115533,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -411,9 +411,9 @@
         "id": 26,
         "poolId": 19,
         "lpAddress": "0x5E74D85311fe2409c341Ce49Ce432BB950D221DE",
-        "totalSupply": 264361668041123879,
-        "totalStaked": 254866831230606820,
-        "totalStakedInUSD": 7710.938397443033,
+        "totalSupply": 241726122650651238,
+        "totalStaked": 232235837926856687,
+        "totalStakedInUSD": 5985.416319288773,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
@@ -424,16 +424,16 @@
         "id": 27,
         "poolId": 20,
         "lpAddress": "0xbe753E99D0dBd12FB39edF9b884eBF3B1B09f26C",
-        "totalSupply": 24559831621955966548712023,
-        "totalStaked": 21522603351768334485882483,
-        "totalStakedInUSD": 8057.444537498692,
+        "totalSupply": 14439939001882108105390252,
+        "totalStaked": 9869611484844832370017945,
+        "totalStakedInUSD": 1846.169766717765,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
-                "apr": 100.44911421565547
+                "apr": 189.03636894283764
             }
         ],
         "chefVersion": "v2"
@@ -442,16 +442,16 @@
         "id": 28,
         "poolId": 21,
         "lpAddress": "0xbC0e71aE3Ef51ae62103E003A9Be2ffDe8421700",
-        "totalSupply": 6150987453895123975295402,
-        "totalStaked": 6140827396730862000795498,
-        "totalStakedInUSD": 30455.086310741073,
+        "totalSupply": 284873318038756769587666,
+        "totalStaked": 274687157113286902579156,
+        "totalStakedInUSD": 1051.1352579575566,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xdcD6D4e2B3e1D1E1E6Fa8C21C8A323DcbecfF970",
-                "apr": 26.57563201021251
+                "apr": 332.01552941007304
             }
         ],
         "chefVersion": "v2"
@@ -460,16 +460,16 @@
         "id": 29,
         "poolId": 22,
         "lpAddress": "0xbceA13f9125b0E3B66e979FedBCbf7A4AfBa6fd1",
-        "totalSupply": 33708701847528618679277125546,
-        "totalStaked": 7625361169672453658940035140,
-        "totalStakedInUSD": 91095.6717428621,
+        "totalSupply": 30814572089319721160216473723,
+        "totalStaked": 5107006920788173001364121768,
+        "totalStakedInUSD": 38465.345666927045,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x918dBe087040A41b786f0Da83190c293DAe24749",
-                "apr": 73.05948479771943
+                "apr": 109.83005649921269
             }
         ],
         "chefVersion": "v2"
@@ -478,16 +478,16 @@
         "id": 30,
         "poolId": 23,
         "lpAddress": "0xBBf3D4281F10E537d5b13CA80bE22362310b2bf9",
-        "totalSupply": 2398580461601081041671045151,
-        "totalStaked": 1171159120913866795527951734,
-        "totalStakedInUSD": 479698.6046404802,
-        "totalRewardRate": 23555.47862212221,
+        "totalSupply": 2613395329989109994568318970,
+        "totalStaked": 1363594625947236111092052143,
+        "totalStakedInUSD": 245535.21331252242,
+        "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 16.985753191662166,
+        "apr": 11.108000801833851,
         "nonTriAPRs": [
             {
                 "address": "0x9f1F933C660a1DC856F0E0Fe058435879c5CCEf0",
-                "apr": 42.0227070038239
+                "apr": 26.042812563440926
             }
         ],
         "chefVersion": "v2"
@@ -496,12 +496,12 @@
         "id": 31,
         "poolId": 24,
         "lpAddress": "0x1e0e812FBcd3EB75D8562AD6F310Ed94D258D008",
-        "totalSupply": 269027705585992366071031674,
-        "totalStaked": 74102877369672406027283046,
-        "totalStakedInUSD": 569080.8948600568,
-        "totalRewardRate": 70666.43586636662,
+        "totalSupply": 243277997910963342631807696,
+        "totalStaked": 48761352268900837537651462,
+        "totalStakedInUSD": 204797.57054068104,
+        "totalRewardRate": 69357.7981651376,
         "allocPoint": 12,
-        "apr": 42.95369346467842,
+        "apr": 39.9527006959124,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -514,12 +514,12 @@
         "id": 32,
         "poolId": 25,
         "lpAddress": "0x20F8AeFB5697B77E0BB835A8518BE70775cdA1b0",
-        "totalSupply": 1601814234261947520899,
-        "totalStaked": 1577139406355535330970,
-        "totalStakedInUSD": 9356489.38273944,
-        "totalRewardRate": 247332.5255322832,
+        "totalSupply": 550009238822750983363,
+        "totalStaked": 527927659593696852843,
+        "totalStakedInUSD": 2513424.7157904203,
+        "totalRewardRate": 242752.29357798165,
         "allocPoint": 42,
-        "apr": 9.143861399373936,
+        "apr": 11.393918408139168,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -532,12 +532,12 @@
         "id": 33,
         "poolId": 26,
         "lpAddress": "0x03B666f3488a7992b2385B12dF7f35156d7b29cD",
-        "totalSupply": 1026964009281608038211,
-        "totalStaked": 993603130754188019181,
-        "totalStakedInUSD": 6082051.272952914,
-        "totalRewardRate": 247332.5255322832,
+        "totalSupply": 438937465863934404836,
+        "totalStaked": 406660145634221171594,
+        "totalStakedInUSD": 1987441.930876283,
+        "totalRewardRate": 242752.29357798165,
         "allocPoint": 42,
-        "apr": 14.066708460835688,
+        "apr": 14.40935490582598,
         "nonTriAPRs": [
             {
                 "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
@@ -550,16 +550,16 @@
         "id": 34,
         "poolId": 27,
         "lpAddress": "0x29C160d2EF4790F9A23B813e7544D99E539c28Ba",
-        "totalSupply": 38427538347990390940845261,
-        "totalStaked": 38411388724490822425528821,
-        "totalStakedInUSD": 42779.855991835284,
+        "totalSupply": 45710270605175552335656451,
+        "totalStaked": 45688108598787246773473104,
+        "totalStakedInUSD": 32947.7250804246,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xE4eB03598f4DCAB740331fa432f4b85FF58AA97E",
-                "apr": 136.53918410684074
+                "apr": 152.1551332531452
             }
         ],
         "chefVersion": "v2"
@@ -568,16 +568,16 @@
         "id": 35,
         "poolId": 28,
         "lpAddress": "0x87BCC091d0A7F9352728100268Ac8D25729113bB",
-        "totalSupply": 2880458660912855431995252,
-        "totalStaked": 2807069758465458018168588,
-        "totalStakedInUSD": 2823052.5710811378,
-        "totalRewardRate": 70666.43586636662,
+        "totalSupply": 9403255719952580725001075,
+        "totalStaked": 9302023948591103503886691,
+        "totalStakedInUSD": 9332698.66891333,
+        "totalRewardRate": 69357.7981651376,
         "allocPoint": 12,
-        "apr": 8.658757036558644,
+        "apr": 0.8767256213164061,
         "nonTriAPRs": [
             {
-                "address": "0x8BEc47865aDe3B172A928df8f990Bc7f2A3b9f79",
-                "apr": 7.7691430155865975
+                "address": "0x5183e1B1091804BC2602586919E6880ac1cf2896",
+                "apr": 12.684247525778474
             }
         ],
         "chefVersion": "v2"
@@ -586,16 +586,16 @@
         "id": 36,
         "poolId": 29,
         "lpAddress": "0x6a29e635BCaB8aBeE1491059728e3D6D11d6A114",
-        "totalSupply": 1020834060295457318221900913,
-        "totalStaked": 1020667854459753079680238496,
-        "totalStakedInUSD": 284447.4867890274,
+        "totalSupply": 1014970700380295855996380594,
+        "totalStaked": 1014695150731204245132293941,
+        "totalStakedInUSD": 151474.19350135094,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0x34F291934b88c7870B7A17835B926B264fc13a81",
-                "apr": 42.39158789142088
+                "apr": 36.45627567987902
             }
         ],
         "chefVersion": "v2"
@@ -604,16 +604,16 @@
         "id": 37,
         "poolId": 30,
         "lpAddress": "0x120e713AD36eCBff171FC8B7cf19FA8B6f6Ba50C",
-        "totalSupply": 84935914893365690486114512,
-        "totalStaked": 84883364115873160726830019,
-        "totalStakedInUSD": 126038.96925865395,
-        "totalRewardRate": 11777.739311061105,
+        "totalSupply": 92127908343823699383447117,
+        "totalStaked": 92122789030377939889796584,
+        "totalStakedInUSD": 63528.328399190344,
+        "totalRewardRate": 11559.633027522936,
         "allocPoint": 2,
-        "apr": 32.32350340824638,
+        "apr": 21.46605628607021,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 51.820033169103404
+                "apr": 64.70983834838346
             }
         ],
         "chefVersion": "v2"
@@ -622,16 +622,16 @@
         "id": 38,
         "poolId": 31,
         "lpAddress": "0x71dBEB011EAC90C51b42854A77C45C1E53242698",
-        "totalSupply": 209734788104710655208451339,
-        "totalStaked": 206563906707909004046996114,
-        "totalStakedInUSD": 120751.68806045919,
-        "totalRewardRate": 23555.47862212221,
+        "totalSupply": 137656296553481791838637839,
+        "totalStaked": 133142916482326022458421683,
+        "totalStakedInUSD": 35488.52201014017,
+        "totalRewardRate": 23119.26605504587,
         "allocPoint": 4,
-        "apr": 67.4776662395666,
+        "apr": 76.8531680630329,
         "nonTriAPRs": [
             {
                 "address": "0x0240aE04c9F47B91Cf47Ca2E7ef44c9De0D385Ac",
-                "apr": 25.798021923820674
+                "apr": 29.033801911048474
             }
         ],
         "chefVersion": "v2"
@@ -640,16 +640,16 @@
         "id": 39,
         "poolId": 32,
         "lpAddress": "0xffb69779f14E851A8c550Bf5bB1933c44BBDE129",
-        "totalSupply": 1992583141358586692471255,
-        "totalStaked": 1962721287381180631098710,
-        "totalStakedInUSD": 1962952.7498885463,
-        "totalRewardRate": 70666.43586636662,
+        "totalSupply": 2616369661050528019303904,
+        "totalStaked": 2583593413674757004850665,
+        "totalStakedInUSD": 2579366.73926604,
+        "totalRewardRate": 69357.7981651376,
         "allocPoint": 12,
-        "apr": 12.452732912604073,
+        "apr": 3.172180176825142,
         "nonTriAPRs": [
             {
                 "address": "0xd80d8688b02B3FD3afb81cDb124F188BB5aD0445",
-                "apr": 11.817797336155234
+                "apr": 8.113102471574656
             }
         ],
         "chefVersion": "v2"
@@ -658,12 +658,12 @@
         "id": 40,
         "poolId": 33,
         "lpAddress": "0xA36DF7c571bEbA7B3fB89F25dFc990EAC75F525A",
-        "totalSupply": 31916155653424567781159172,
-        "totalStaked": 31908742839908434257102564,
-        "totalStakedInUSD": 160865.5531515195,
-        "totalRewardRate": 29444.34827765276,
+        "totalSupply": 81097128117989462375542006,
+        "totalStaked": 81049244022451200881491733,
+        "totalStakedInUSD": 323894.2260666379,
+        "totalRewardRate": 28899.082568807335,
         "allocPoint": 5,
-        "apr": 63.31406837246622,
+        "apr": 10.525833462190253,
         "nonTriAPRs": [],
         "chefVersion": "v2"
     },
@@ -671,16 +671,16 @@
         "id": 41,
         "poolId": 34,
         "lpAddress": "0x53b65177803993C84F31AF4aE7E52FEB171b3b84",
-        "totalSupply": 627587219918390706878964,
-        "totalStaked": 255221876466106018167480,
-        "totalStakedInUSD": 100100.9578849233,
-        "totalRewardRate": 35333.21793318331,
+        "totalSupply": 1146374235218458284779072,
+        "totalStaked": 772854447031793978330260,
+        "totalStakedInUSD": 137551.7248622425,
+        "totalRewardRate": 34678.8990825688,
         "allocPoint": 6,
-        "apr": 122.09736465521588,
+        "apr": 29.742324377452533,
         "nonTriAPRs": [
             {
                 "address": "0x221292443758F63563a1ed04b547278B05845FCb",
-                "apr": 93.60572001437791
+                "apr": 37.30781045392557
             }
         ],
         "chefVersion": "v2"
@@ -689,16 +689,52 @@
         "id": 42,
         "poolId": 35,
         "lpAddress": "0x25bED9DDD30c21a698ba0654f8Da0F381CA1A67b",
-        "totalSupply": 80189519238236795148619582583,
-        "totalStaked": 80186613227468800794164874376,
-        "totalStakedInUSD": 33973.50796422305,
+        "totalSupply": 171547397845685730055011555852,
+        "totalStaked": 171499842509712342391982187298,
+        "totalStakedInUSD": 46105.93842726219,
         "totalRewardRate": 0.0,
         "allocPoint": 0,
         "apr": 0.0,
         "nonTriAPRs": [
             {
                 "address": "0xc21Ff01229e982d7c8b8691163B0A3Cb8F357453",
-                "apr": 173.0628793137813
+                "apr": 80.26434483667357
+            }
+        ],
+        "chefVersion": "v2"
+    },
+    {
+        "id": 43,
+        "poolId": 36,
+        "lpAddress": "0x044b6B0CD3Bb13D2b9057781Df4459C66781dCe7",
+        "totalSupply": 3379628031414345438653321348,
+        "totalStaked": 382911959082873740629324214,
+        "totalStakedInUSD": 48847.79135783789,
+        "totalRewardRate": 23119.26605504587,
+        "allocPoint": 4,
+        "apr": 55.834773088800425,
+        "nonTriAPRs": [
+            {
+                "address": "0x09C9D464b58d96837f8d8b6f4d9fE4aD408d3A4f",
+                "apr": 42.11561376610639
+            }
+        ],
+        "chefVersion": "v2"
+    },
+    {
+        "id": 44,
+        "poolId": 37,
+        "lpAddress": "0x2e5F03c34A771F50C97E8f77EF801C426636e5Cd",
+        "totalSupply": 196429934197258334571,
+        "totalStaked": 0,
+        "totalStakedInUSD": 0.0,
+        "totalRewardRate": 0.0,
+        "allocPoint": 0,
+        "apr": 0,
+        "nonTriAPRs": [
+            {
+                "address": "0x09C9D464b58d96837f8d8b6f4d9fE4aD408d3A4f",
+                "apr": 0
             }
         ],
         "chefVersion": "v2"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -62,6 +62,7 @@ HAK_ADDRESS = "0x5ac53F985ea80c6Af769b9272F35F122201D0F56"
 MFF_ADDRESS = "0x78B65477bBa78fc11735801D559C386611d07529"
 ETHERNAL_ADDRESS = "0x17cbd9C274e90C537790C51b4015a65cD015497e"
 AURIGAMI_ADDRESS = "0x09C9D464b58d96837f8d8b6f4d9fE4aD408d3A4f"
+AURIGAMI_USDC_ADDRESS = "0x4f0d864b1ABf4B701799a0b30b57A22dFEB5917b"
 POLARIS_ORBITAL_ADDRESS = "0x3AC55eA8D2082fAbda674270cD2367dA96092889"
 USP_ADDRESS = "0xa69d9Ba086D41425f35988613c156Db9a88a1A96"
 VAPORWAVE_ADDRESS = "0x2451dB68DeD81900C4F16ae1af597E9658689734"
@@ -302,10 +303,6 @@ V2_POOLS = {
         "CoingeckoRewarderTokenName": "",
         "RewarderPriceLP": "",
         "RewarderTokenDecimals": "",
-        "Rewarder": ZERO_ADDRESS,
-        "CoingeckoRewarderTokenName": "",
-        "RewarderPriceLP": "",
-        "RewarderTokenDecimals": "",
     },
     19: {
         "LP": "0x5E74D85311fe2409c341Ce49Ce432BB950D221DE",
@@ -421,8 +418,21 @@ V2_POOLS = {
     },
 }
 
-V2_STABLEPOOL_SWAP_CONTRACT = {
-    18: {"poolContract": "0x13e7a001EC72AB30D66E2f386f677e25dCFF5F59"},
-    28: {"poolContract": "0x458459E48dbAC0C8Ca83F8D0b7b29FEfE60c3970"},
-    32: {"poolContract": "0x3CE7AAD78B9eb47Fd2b487c463A17AAeD038B7EC"},
+V2_STABLEPOOL_METADATA = {
+    18: {
+        "poolContract": "0x13e7a001EC72AB30D66E2f386f677e25dCFF5F59",
+        "referenceToken": USDC_ADDRESS,
+    },
+    28: {
+        "poolContract": "0x458459E48dbAC0C8Ca83F8D0b7b29FEfE60c3970",
+        "referenceToken": USDC_ADDRESS,
+    },
+    32: {
+        "poolContract": "0x3CE7AAD78B9eb47Fd2b487c463A17AAeD038B7EC",
+        "referenceToken": USDC_ADDRESS,
+    },
+    37: {
+        "poolContract": "0x46F27692de8aA76E86e7E665e573828b9ddcB2b8",
+        "referenceToken": AURIGAMI_USDC_ADDRESS,
+    },
 }

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -418,6 +418,8 @@ V2_POOLS = {
     },
 }
 
+# For Stable Pools: Add the `poolContract` and address of a reference token
+# All other data should populate from trisolaris_core automation
 V2_STABLEPOOL_METADATA = {
     18: {
         "poolContract": "0x13e7a001EC72AB30D66E2f386f677e25dCFF5F59",

--- a/utils/node.py
+++ b/utils/node.py
@@ -71,6 +71,10 @@ def init_erc20(erc20_address):
     return init_contract(erc20_address, "abi/erc20.json")
 
 
+def init_aurigami_erc20(au_erc20_address):
+    return init_contract(au_erc20_address, "abi/au_erc20.json")
+
+
 @memoize
 def getTokenSymbol(address):
     token = init_erc20(address)

--- a/utils/prices.py
+++ b/utils/prices.py
@@ -9,22 +9,20 @@ from .constants import (
     TRIBAR_ADDRESS,
     ZERO_ADDRESS,
 )
-from .node import init_erc20, init_tlp
+from .node import init_aurigami_erc20, init_erc20, init_tlp
+
 
 def getTokenUSDRatio(w3, pool, rewarder_address, wnearUsdRatio, triUsdRatio):
     if pool["Rewarder"] == ZERO_ADDRESS:
         return 0
-    elif pool['CoingeckoRewarderTokenName'] != "":
-        return getCoingeckoUSDPriceRatio(pool['CoingeckoRewarderTokenName'])
+    elif pool["CoingeckoRewarderTokenName"] != "":
+        return getCoingeckoUSDPriceRatio(pool["CoingeckoRewarderTokenName"])
     else:
         return getDexTokenUSDRatio(
-            w3, 
-            pool["RewarderPriceLP"], 
-            rewarder_address, 
-            wnearUsdRatio, 
-            triUsdRatio
-            )
-        
+            w3, pool["RewarderPriceLP"], rewarder_address, wnearUsdRatio, triUsdRatio
+        )
+
+
 # Takes a TLP token with either USDC, USDT or WNEAR and returns the token price in USD
 # NOTE: the prices are returned in USD and NOT USDC
 def getDexTokenUSDRatio(w3, tlp_address, token_address, wnearUsdRatio=0, triUsdRatio=0):
@@ -36,16 +34,25 @@ def getDexTokenUSDRatio(w3, tlp_address, token_address, wnearUsdRatio=0, triUsdR
     t0_decimals = init_erc20(t0).functions.decimals().call()
     reserves = pair.functions.getReserves().call()
     if t0 == token_address:
-        tokenReserveRatio = reserves[0]*(10**(t1_decimals-t0_decimals))/reserves[1]
+        tokenReserveRatio = (
+            reserves[0] * (10 ** (t1_decimals - t0_decimals)) / reserves[1]
+        )
     else:
-        tokenReserveRatio = reserves[1]*(10**(t0_decimals-t1_decimals))/reserves[0]
-    
+        tokenReserveRatio = (
+            reserves[1] * (10 ** (t0_decimals - t1_decimals)) / reserves[0]
+        )
+
     ## Converting it into price
-    if (t1 == USDC_ADDRESS or t0 == USDC_ADDRESS or t1 == USDT_ADDRESS or t0 == USDT_ADDRESS):
+    if (
+        t1 == USDC_ADDRESS
+        or t0 == USDC_ADDRESS
+        or t1 == USDT_ADDRESS
+        or t0 == USDT_ADDRESS
+    ):
         return tokenReserveRatio
-    elif (t1 == WNEAR_ADDRESS or t0 == WNEAR_ADDRESS):
+    elif t1 == WNEAR_ADDRESS or t0 == WNEAR_ADDRESS:
         return tokenReserveRatio * wnearUsdRatio
-    elif (t1 == TRI_ADDRESS or t0 == TRI_ADDRESS):
+    elif t1 == TRI_ADDRESS or t0 == TRI_ADDRESS:
         return tokenReserveRatio * triUsdRatio
     else:
         raise ValueError("TLP does not have wnear, tri or usd as base token")
@@ -58,23 +65,38 @@ def getCoingeckoUSDPriceRatio(asset):
 
         if coingecko_api_key:
             coingecko_query_params["x_cg_pro_api_key"] = coingecko_api_key
-            coingecko_api_endpoint_root = "https://pro-api.coingecko.com/api/v3/simple/price"
+            coingecko_api_endpoint_root = (
+                "https://pro-api.coingecko.com/api/v3/simple/price"
+            )
         else:
-            coingecko_api_endpoint_root = "https://api.coingecko.com/api/v3/simple/price"
-        
-        coingecko_encoded_query_params = parse.urlencode(coingecko_query_params, doseq=False)
-        coingecko_api_endpoint = f"{coingecko_api_endpoint_root}?{coingecko_encoded_query_params}"
-        
+            coingecko_api_endpoint_root = (
+                "https://api.coingecko.com/api/v3/simple/price"
+            )
+
+        coingecko_encoded_query_params = parse.urlencode(
+            coingecko_query_params, doseq=False
+        )
+        coingecko_api_endpoint = (
+            f"{coingecko_api_endpoint_root}?{coingecko_encoded_query_params}"
+        )
+
         response = requests.get(coingecko_api_endpoint)
-        usd_price = (response.json()[asset]['usd'])
-        return 1/usd_price
+        usd_price = response.json()[asset]["usd"]
+        return 1 / usd_price
     except requests.exceptions.RequestException as e:
         print(f"Coingecko API Call Error: {e}")
         return 0
+
 
 def getTriXTriRatio(w3):
     xtri = init_erc20(TRIBAR_ADDRESS)
     tri = init_erc20(TRI_ADDRESS)
     xtri_supply = xtri.functions.totalSupply().call()
     tri_locked = tri.functions.balanceOf(TRIBAR_ADDRESS).call()
-    return tri_locked/xtri_supply
+    return tri_locked / xtri_supply
+
+
+def getAurigamiERC20ExchangeRate(au_erc20_address):
+    au_token = init_aurigami_erc20(au_erc20_address)
+    au_token_exchange_rate = au_token.functions.exchangeRateStored().call()
+    return au_token_exchange_rate

--- a/utils/rewarder_configs.py
+++ b/utils/rewarder_configs.py
@@ -2,7 +2,7 @@ import requests
 from retry import retry
 from web3 import Web3
 
-from utils.constants import ZERO_ADDRESS
+from utils.constants import V2_STABLEPOOL_METADATA, ZERO_ADDRESS
 
 REWARDER_CONFIG_ENDPOINT = "https://raw.githubusercontent.com/trisolaris-labs/trisolaris_core/main/rewarderConfigs.json"
 
@@ -35,7 +35,7 @@ def formatRewarderConfigItem(rewarder_config_item):
     id = rewarder_config_item["PoolId"]
     pool = {
         "LP": Web3.toChecksumAddress(rewarder_config_item["LPToken"]),
-        "LPType": "",
+        "LPType": "StableAMM" if id in V2_STABLEPOOL_METADATA else "",
         "Rewarder": Web3.toChecksumAddress(rewarder),
         "CoingeckoRewarderTokenName": coingecko_token_name,
         "RewarderPriceLP": rewarder_price_lp,

--- a/utils/rewarder_configs.py
+++ b/utils/rewarder_configs.py
@@ -2,7 +2,7 @@ import requests
 from retry import retry
 from web3 import Web3
 
-from utils.constants import V2_STABLEPOOL_METADATA, ZERO_ADDRESS
+from utils.constants import ZERO_ADDRESS
 
 REWARDER_CONFIG_ENDPOINT = "https://raw.githubusercontent.com/trisolaris-labs/trisolaris_core/main/rewarderConfigs.json"
 
@@ -25,6 +25,9 @@ def formatRewarderConfigItem(rewarder_config_item):
     coingecko_token_name = _getOptionalValueFromRewarderConfigItem(
         rewarder_config_item, "CoingeckoRewarderTokenName"
     )
+    is_stable_pool = _getOptionalValueFromRewarderConfigItem(
+        rewarder_config_item, "isStablePool", False
+    )
     rewarder_price_lp = _getOptionalValueFromRewarderConfigItem(
         rewarder_config_item, "RewarderPriceLP"
     )
@@ -35,7 +38,7 @@ def formatRewarderConfigItem(rewarder_config_item):
     id = rewarder_config_item["PoolId"]
     pool = {
         "LP": Web3.toChecksumAddress(rewarder_config_item["LPToken"]),
-        "LPType": "StableAMM" if id in V2_STABLEPOOL_METADATA else "",
+        "LPType": "StableAMM" if is_stable_pool else "",
         "Rewarder": Web3.toChecksumAddress(rewarder),
         "CoingeckoRewarderTokenName": coingecko_token_name,
         "RewarderPriceLP": rewarder_price_lp,


### PR DESCRIPTION
Stable pools' `virtual price` shows the value of `1` LP token relative to each pool's underlying assets.

In order to show APR for stable pools, I've added a `referenceToken` key to be used as the canonical price for the tokens represented in a stable pool.

The `referenceToken`'s USD value is multiplied by the pool's `virtualPrice` to give a `virtualPrice` in USD, instead of relative to the pool's token type.

Examples:
- USDC/USDT pool
  -  virtual price: 1
  - reference token: USDC ($1)
  - virtual price in USD: 1 * $1 = $1
  - If this pool had 100 LP tokens, the pool's value would be $100 (100 * $1)
- auUSDC/auUSDT pool
  -  virtual price: 1
  - reference token: auUSDC ($0.02)
  - virtual price in USD: 1 * $0.02 = $0.02
  - If this pool had 100 LP tokens, the pool's value would be $2 (100 * $0.02)